### PR TITLE
Increment version to 0.2.0-dev (again)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Release 0.2.0 (development release)
+
 ## Release 0.1.1 (current release)
 
 ### New features since last release

--- a/xcc/_version.py
+++ b/xcc/_version.py
@@ -3,4 +3,4 @@ This module specifies the XCC version number (<major>.<minor>.<patch>[-<pre-rele
 See https://semver.org/.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.2.0-dev"


### PR DESCRIPTION
This PR increments the XCC version to `0.2.0-dev` following the `0.1.1` release.