### PR TITLE
Allow nameless jobs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release 0.2.0 (development release)
 
+### Improvements
+
+* Following an update to the Xanadu Cloud 0.4.0 API, names are no longer required to submit jobs.
+  [(#16)](https://github.com/XanaduAI/xanadu-cloud-client/pull/16)
+
 ## Release 0.1.1 (current release)
 
 ### New features since last release

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -89,15 +89,16 @@ class TestJob:
         want_params = {"size": str(limit)}
         assert have_params == want_params
 
+    @pytest.mark.parametrize("name", [None, "foo"])
     @responses.activate
-    def test_submit(self, job_id, connection):
+    def test_submit(self, job_id, connection, name):
         """Tests that a job can be submitted."""
-        details = json.dumps({"id": job_id, "name": "foo"})
+        details = json.dumps({"id": job_id, "name": name})
         responses.add(responses.POST, connection.url("/jobs"), status=200, body=details)
 
-        job = xcc.Job.submit(connection, name="foo", target="bar", circuit="baz", language="qux")
+        job = xcc.Job.submit(connection, name=name, target="bar", circuit="baz", language="qux")
         assert job.id == job_id
-        assert job.name == "foo"
+        assert job.name == name
 
     def test_id(self, job):
         """Tests that the correct ID is returned for a job."""
@@ -220,11 +221,12 @@ class TestJob:
         add_response(body={"language": "foo"})
         assert job.language == "foo"
 
+    @pytest.mark.parametrize("name", [None, "foo"])
     @responses.activate
-    def test_name(self, job, add_response):
+    def test_name(self, job, add_response, name):
         """Tests that the correct name is returned for a job."""
-        add_response(body={"name": "foo"})
-        assert job.name == "foo"
+        add_response(body={"name": name})
+        assert job.name == name
 
     @responses.activate
     def test_target(self, job, add_response):

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -5,7 +5,7 @@ This module implements the Xanadu Cloud CLI.
 import functools
 import json
 import sys
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Mapping, Sequence, Tuple, Union
 
 import fire
 from fire.core import FireError

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -5,7 +5,7 @@ This module implements the Xanadu Cloud CLI.
 import functools
 import json
 import sys
-from typing import Any, Callable, Mapping, Sequence, Tuple, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
 
 import fire
 from fire.core import FireError
@@ -273,14 +273,16 @@ def list_jobs(limit: int = 10) -> Sequence[Mapping]:
 
 
 @beautify
-def submit_job(name: str, target: str, circuit: str, language: str = "blackbird:1.0") -> Mapping:
+def submit_job(
+    target: str, circuit: str, language: str = "blackbird:1.0", name: str = None
+) -> Mapping:
     """Submits a job to the Xanadu Cloud.
 
     Args:
-        name (str): Name of the job.
         target (str): Target of the job.
         circuit (str): Circuit of the job.
         language (str): Language of the job.
+        name (str, optional): Name of the job.
 
     Returns:
         Mapping: Overview of the submitted job.

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -115,12 +115,14 @@ class Job:
         return jobs
 
     @staticmethod
-    def submit(connection: Connection, name: str, target: str, circuit: str, language: str) -> Job:
+    def submit(
+        connection: Connection, name: Optional[str], target: str, circuit: str, language: str
+    ) -> Job:
         """Submits a job to the Xanadu Cloud.
 
         Args:
             connection (Connection): connection to the Xanadu Cloud
-            name (str): name of the job
+            name (str, optional): name of the job
             target (str): target of the job
             circuit (str): circuit of the job
             language (str): language of the job
@@ -264,11 +266,11 @@ class Job:
         return self._details["language"]
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         """Returns the name of a job.
 
         Returns:
-            str: name of this job
+            str, optional: name of this job
         """
         return self._details["name"]
 


### PR DESCRIPTION
**Context:**
After version 0.1.1 of the XCC was released, the Xanadu Cloud 0.4.0 API was updated to allow optional job names.

**Description of the Change:**
* The `Job.submit()` function now accepts `None` as a value for the `name` parameter.
* The `xcc job submit` command no longer requires a `name` flag.

**Benefits:**
* The Job submission API is more flexible and requires less keystrokes to use.

**Possible Drawbacks:**
* Any existing code which assumes `Job.name` is a `str` must be adapted for the case where it is `None` instead.

**Related GitHub Issues:**
None.