### PR TITLE
Increment version to 0.1.2

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,12 @@
 * Following an update to the Xanadu Cloud 0.4.0 API, names are no longer required to submit jobs.
   [(#16)](https://github.com/XanaduAI/xanadu-cloud-client/pull/16)
 
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
 ## Release 0.1.1
 
 ### New features since last release

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,11 +1,11 @@
-## Release 0.2.0 (development release)
+## Release 0.1.2 (current release)
 
 ### Improvements
 
 * Following an update to the Xanadu Cloud 0.4.0 API, names are no longer required to submit jobs.
   [(#16)](https://github.com/XanaduAI/xanadu-cloud-client/pull/16)
 
-## Release 0.1.1 (current release)
+## Release 0.1.1
 
 ### New features since last release
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,33 @@
+name: Upload
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Install XIR
+        run: make install dist wheel
+
+      - name: Run tests
+        run: make test
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ isort[colors]==5.9.3
 pylint==2.11.1
 pytest-cov==3.0.0
 responses==0.14.0
+wheel==0.37.1

--- a/xcc/_version.py
+++ b/xcc/_version.py
@@ -3,4 +3,4 @@ This module specifies the XCC version number (<major>.<minor>.<patch>[-<pre-rele
 See https://semver.org/.
 """
 
-__version__ = "0.2.0-dev"
+__version__ = "0.1.2"


### PR DESCRIPTION
**Context:**
A new patch release of the XCC is desirable to support the submission of nameless jobs.

**Description of the Change:**
- A new GitHub Actions workflow has been to added to automate PyPI releases.
    - See XanaduAI/xir#9 for more details.
- The XCC package version has been set to `0.1.2`.

**Benefits:**
- Users are no longer forced to supply job names to the XCC during job submission.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.