### PR TITLE
Increment version to 0.2.0-dev (again) (again)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Release 0.2.0 (development release)
+
 ## Release 0.1.2 (current release)
 
 ### Improvements

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Release 0.2.0 (development release)
 
+### New features since last release
+
+### Breaking Changes
+
+### Bug fixes
+
+### Documentation
+
+### Contributors
+
 ## Release 0.1.2 (current release)
 
 ### Improvements

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -20,7 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      - name: Install XIR
+      - name: Install XCC
         run: make install dist wheel
 
       - name: Run tests

--- a/xcc/_version.py
+++ b/xcc/_version.py
@@ -3,4 +3,4 @@ This module specifies the XCC version number (<major>.<minor>.<patch>[-<pre-rele
 See https://semver.org/.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.2.0-dev"


### PR DESCRIPTION
This PR increments the XCC version to `0.2.0-dev` following the `0.1.2` release.