### PR TITLE
Add license file to distribution

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,9 +6,16 @@
 
 ### Bug fixes
 
+* The license file is included in the source distribution, even when using `setuptools <56.0.0`.
+   [(#20)](https://github.com/XanaduAI/xanadu-cloud-client/pull/20)
+
 ### Documentation
 
 ### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Bastian Zimmermann](https://github.com/BastianZim)
 
 ## Release 0.1.2 (current release)
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ info = {
     "entry_points": {"console_scripts": ["xcc=xcc.commands:main"]},
     "install_requires": requirements,
     "license": "Apache License 2.0",
+    "license_files": ("LICENSE"),
     "long_description_content_type": "text/x-rst",
     "long_description": open("README.rst").read(),
     "maintainer_email": "software@xanadu.ai",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ info = {
     "entry_points": {"console_scripts": ["xcc=xcc.commands:main"]},
     "install_requires": requirements,
     "license": "Apache License 2.0",
-    "license_files": ("LICENSE"),
+    "license_files": ["LICENSE"],
     "long_description_content_type": "text/x-rst",
     "long_description": open("README.rst").read(),
     "maintainer_email": "software@xanadu.ai",


### PR DESCRIPTION
**Context:** Currently, the license file is not included in the distribution.

**Description of the Change:** The license file is now included in the distribution.

**Benefits:** Downstream distributors don't need to separately download the license.

**Possible Drawbacks:**

**Related GitHub Issues:**