### PR TITLE
Add support for initializing Connections from Settings instances

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,12 +2,25 @@
 
 ### New features since last release
 
+* The `Connection` class can now load connections from `Settings` instances.
+  [(#22)](https://github.com/XanaduAI/xanadu-cloud-client/pull/22)
+
+  ```python
+  import xcc
+
+  # Initialize a Connection using an implicit Settings instance.
+  connection = xcc.Connection.load()
+
+  # Initialize a Connection using an explicit Settings instance.
+  connection = xcc.Connection.load(settings=xcc.Settings())
+  ```
+
 ### Breaking Changes
 
 ### Bug fixes
 
 * The license file is included in the source distribution, even when using `setuptools <56.0.0`.
-   [(#20)](https://github.com/XanaduAI/xanadu-cloud-client/pull/20)
+  [(#20)](https://github.com/XanaduAI/xanadu-cloud-client/pull/20)
 
 ### Documentation
 
@@ -34,7 +47,7 @@ This release contains contributions from (in alphabetical order):
 
 ### New features since last release
 
-* The Job class now has a `metadata` property which, by convention, returns
+* The `Job` class now has a `metadata` property which, by convention, returns
   information about job failures.
   [(#15)](https://github.com/XanaduAI/xanadu-cloud-client/pull/15)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features since last release
 
-* The `Connection` class can now load connections from `Settings` instances.
+* The Connection class can now load a Connection from a Settings instance.
   [(#22)](https://github.com/XanaduAI/xanadu-cloud-client/pull/22)
 
   ```python
@@ -47,7 +47,7 @@ This release contains contributions from (in alphabetical order):
 
 ### New features since last release
 
-* The `Job` class now has a `metadata` property which, by convention, returns
+* The Job class now has a `metadata` property which, by convention, returns
   information about job failures.
   [(#15)](https://github.com/XanaduAI/xanadu-cloud-client/pull/15)
 
@@ -66,7 +66,7 @@ This release contains contributions from (in alphabetical order):
 * Individual modules are now listed in the *API* section of the Sphinx sidebar.
   [(#15)](https://github.com/XanaduAI/xanadu-cloud-client/pull/15)
 
-* The `Settings` class docstring now includes an example walkthrough as well as
+* The Settings class docstring now includes an example walkthrough as well as
   the location of the XCC configuration file.
   [(#15)](https://github.com/XanaduAI/xanadu-cloud-client/pull/15)
 

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Afterwards, you can verify that your API key was set correctly using either:
 
         import xcc
 
-        connection = xcc.commands.load_connection()
+        connection = xcc.Connection.load()
         assert connection.ping().ok
 
 .. inclusion-marker-for-setup-end

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==21.9b0
+black==22.3.0
 build==0.7.0
 isort[colors]==5.9.3
 pylint==2.11.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,4 +25,8 @@ def settings(monkeypatch) -> Iterator[xcc.Settings]:
         # Saving ensures that new Settings instances are loaded with the same values.
         settings_.save()
 
+        # Environment variables take precedence over fields in the .env file.
+        for env_var in map(xcc.settings.get_name_of_env_var, settings_.dict()):
+            monkeypatch.delenv(env_var, raising=False)
+
         yield settings_

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -16,6 +16,45 @@ import xcc
 class TestConnection:
     """Tests the :class:`xcc.Connection` class."""
 
+    @pytest.mark.usefixtures("settings")
+    def test_load_with_implicit_settings(self):
+        """Tests that a connection can be loaded with an implicit settings configuration."""
+        connection = xcc.Connection.load()
+        assert connection.refresh_token == "j.w.t"
+        assert connection.access_token is None
+        assert connection.host == "example.com"
+        assert connection.port == 80
+        assert connection.tls is False
+
+    @pytest.mark.usefixtures("settings")
+    def test_load_with_explicit_settings(self):
+        """Tests that a connection can be loaded with an explicit settings configuration."""
+        settings = xcc.Settings(
+            REFRESH_TOKEN=None,
+            ACCESS_TOKEN="j.w.t",
+            HOST="not.example.com",
+            PORT=443,
+            TLS=True,
+        )
+
+        connection = xcc.Connection.load(settings)
+        assert connection.refresh_token is None
+        assert connection.access_token == "j.w.t"
+        assert connection.host == "not.example.com"
+        assert connection.port == 443
+        assert connection.tls is True
+
+    @pytest.mark.usefixtures("settings")
+    def test_load_with_keyword_arguments(self):
+        """Tests that a connection can be loaded with new or overriden keyword arguments."""
+        connection = xcc.Connection.load(host="not.example.com", headers={"User-Agent": "Bond"})
+        assert connection.refresh_token == "j.w.t"
+        assert connection.access_token is None
+        assert connection.host == "not.example.com"
+        assert connection.port == 80
+        assert connection.tls is False
+        assert connection.user_agent == "Bond"
+
     def test_missing_access_token_and_refresh_token(self):
         """Tests that a ValueError is raised when a connection is created
         without a refresh token or an access token.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -46,7 +46,7 @@ class TestConnection:
 
     @pytest.mark.usefixtures("settings")
     def test_load_with_keyword_arguments(self):
-        """Tests that a connection can be loaded with new or overriden keyword arguments."""
+        """Tests that a connection can be loaded with new or overridden keyword arguments."""
         connection = xcc.Connection.load(host="not.example.com", headers={"User-Agent": "Bond"})
         assert connection.refresh_token == "j.w.t"
         assert connection.access_token is None

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -50,7 +50,7 @@ def load_connection() -> Connection:
 
     .. warning::
 
-        This is an internal XCC utility function and should _not_ be called from
+        This is an internal XCC utility function and should *not* be called from
         outside the XCC package. Use :func:`xcc.Connection.load()` instead.
     """
     return Connection.load(headers={"User-Agent": f"XCC/{__version__} (CLI)"})

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -2,9 +2,9 @@
 This module implements the Xanadu Cloud CLI.
 """
 
-import functools
 import json
 import sys
+from functools import wraps
 from typing import Any, Callable, Mapping, Sequence, Tuple, Union
 
 import fire
@@ -30,7 +30,7 @@ def beautify(command: Callable) -> Callable:
         CLI command into a JSON string if the value is a list or dictionary
     """
 
-    @functools.wraps(command)
+    @wraps(command)
     def beautify_(*args, **kwargs):
         output = command(*args, **kwargs)
         if isinstance(output, (list, dict)):
@@ -41,21 +41,14 @@ def beautify(command: Callable) -> Callable:
 
 
 def load_connection() -> Connection:
-    """Loads a connection using the :class:`xcc.Settings` class.
+    """Loads a connection using :func:`xcc.Connection.load()` with a "User-Agent"
+    header that specifies the Xanadu Cloud Client CLI.
 
     Returns:
-        Connection: connection initialized from the configuration of a new
-        :class:`xcc.Settings` instance
+        Connection: connection with a "User-Agent" header that is appropriate
+        for the CLI, loaded from a new :class:`xcc.Settings` instance
     """
-    settings = Settings()
-    return Connection(
-        refresh_token=settings.REFRESH_TOKEN,
-        access_token=settings.ACCESS_TOKEN,
-        host=settings.HOST,
-        port=settings.PORT,
-        tls=settings.TLS,
-        headers={"User-Agent": f"XCC/{__version__} (CLI)"},
-    )
+    return Connection.load(headers={"User-Agent": f"XCC/{__version__} (CLI)"})
 
 
 # Settings CLI

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -47,6 +47,11 @@ def load_connection() -> Connection:
     Returns:
         Connection: connection with a "User-Agent" header that is appropriate
         for the CLI, loaded from a new :class:`xcc.Settings` instance
+
+    .. warning::
+
+        This is an internal XCC utility function and should _not_ be called from
+        outside the XCC package. Use :func:`xcc.Connection.load()` instead.
     """
     return Connection.load(headers={"User-Agent": f"XCC/{__version__} (CLI)"})
 

--- a/xcc/connection.py
+++ b/xcc/connection.py
@@ -1,12 +1,15 @@
 """
 This module contains the :class:`~xcc.Connection` class.
 """
+from __future__ import annotations
+
 from itertools import chain
 from typing import Dict, List, Optional
 
 import requests
 
 from ._version import __version__
+from .settings import Settings
 
 
 class Connection:
@@ -74,6 +77,31 @@ class Connection:
         "status": "online"
     }
     """
+
+    @staticmethod
+    def load(settings: Optional[Settings] = None, **kwargs) -> Connection:
+        """Loads a connection using the given :class:`xcc.Settings` instance,
+        or a new :class:`xcc.Settings` instance if one is not provided.
+
+        Args:
+            settings (Settings, optional): Xanadu Cloud connection settings
+            kwargs: keyword arguments to override in the call to :func:`xcc.Connection.__init__()`
+
+        Returns:
+            Connection: connection initialized from the configuration of the
+            provided (or created) :class:`xcc.Settings` instance
+        """
+        settings = settings or Settings()
+        return Connection(
+            **{
+                "refresh_token": settings.REFRESH_TOKEN,
+                "access_token": settings.ACCESS_TOKEN,
+                "host": settings.HOST,
+                "port": settings.PORT,
+                "tls": settings.TLS,
+                **kwargs,
+            }
+        )
 
     def __init__(
         self,


### PR DESCRIPTION
**Context:**
One of the most common operations performed by XCC users after configuring their Xanadu Cloud API key is creating a new Connection instance. The easiest way to do this _without_ invoking the (private) `xcc.commands.load_connection()` function is to initialize a Settings instance and manually specify each keyword argument to `Connection.__init__()`; however, this is quite tedious and leads to a suboptimal user experience.

**Description of the Change:**
* Added the `Connection.load()` function which creates a Connection object from an implicit or explicit Settings instance.

```python
import xcc

# Initialize a Connection using an implicit Settings instance.
connection = xcc.Connection.load()

# Initialize a Connection using an explicit Settings instance.
connection = xcc.Connection.load(settings=xcc.Settings())
```

**Benefits:**
* It is easier to instantiate a Connection instance using environment variables or the Xanadu Cloud .env file.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.