### PR TITLE
Stream job results in chunks

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,11 @@
 
 ### Breaking Changes
 
+### Improvements
+
+* Job results are now streamed in chunks to support large payloads.
+  [(#23)](https://github.com/XanaduAI/xanadu-cloud-client/pull/23)
+
 ### Bug fixes
 
 * The license file is included in the source distribution, even when using `setuptools <56.0.0`.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -235,6 +235,16 @@ class TestConnection:
         with pytest.raises(HTTPError, match=r"403 Client Error: Forbidden"):
             connection.request("GET", "/healthz")
 
+    @responses.activate
+    def test_request_failure_due_to_status_code_while_streaming(self, connection):
+        """Tests that an HTTPError is raised when the status code of the HTTP
+        response to a connection request where ``stream=True`` indicates that
+        an error has occurred.
+        """
+        responses.add(responses.GET, connection.url("healthz"), status=403, body="{}")
+        with pytest.raises(HTTPError, match=r"403 Client Error: Forbidden"):
+            connection.request("GET", "/healthz", stream=True)
+
     def test_request_failure_due_to_timeout(self, monkeypatch, connection):
         """Tests that a RequestException is raised when a connection request times out."""
 

--- a/xcc/connection.py
+++ b/xcc/connection.py
@@ -241,6 +241,11 @@ class Connection:
             self.update_access_token()
             response = self._request(method=method, url=url, headers=self.headers, **kwargs)
 
+        if kwargs.get("stream", False) is True:
+            # Avoid eagerly fetching the content for streaming requests.
+            response.raise_for_status()
+            return response
+
         try:
             body = response.json()
 


### PR DESCRIPTION
**Context:**

Currently, fetching large job results (e.g., those on the order of GBs) can take an unreasonably long time due to the memory overhead associated with the default fetching strategy of the [requests](https://docs.python-requests.org/en/latest/) library. Fetching the same job result from a web browser (e.g., Firefox) tends to be much faster presumably due to the streaming nature of the download.

**Description of the Change:**
* Modified Connection.request() to respect the `stream` keyword argument during error handling.
* Modified Job.result to stream job results from the Xanadu Cloud platform in chunks.

**Benefits:**
* Large job results are fetched _significantly_ faster, even more so as the size of the job result grows.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.