### PR TITLE
GitHub Actions workflows for version bumps

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-[Bastian Zimmermann](https://github.com/BastianZim)
+[Mikhail Andrenkov](https://github.com/Mandrenkov), [Bastian Zimmermann](https://github.com/BastianZim).
 
 ## Release 0.1.2 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -30,8 +30,6 @@
   xcc.Job.list(connection, ids=["<UUID 1>", "<UUID 2>", ...])
   ```
 
-### Breaking Changes
-
 ### Improvements
 
 * Job results are now streamed in chunks to support large payloads.
@@ -41,8 +39,6 @@
 
 * The license file is included in the source distribution, even when using `setuptools <56.0.0`.
   [(#20)](https://github.com/XanaduAI/xanadu-cloud-client/pull/20)
-
-### Documentation
 
 ### Contributors
 

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -1,0 +1,52 @@
+name: Post-Release Version Bump
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  post_release_version_bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Derive versions
+        id: versions
+        run: |
+          old_version=`grep -oP '(?<=__version__ = ").*(?=")' xcc/_version.py`
+          new_version=`echo $old_version | awk '{split($0,v,"."); print v[1] "." v[2]+1 ".0-dev"}'`
+
+          echo "::set-output name=old_version::$old_version"
+          echo "::set-output name=new_version::$new_version"
+
+      - name: Bump version in _version.py
+        run:
+          sed -i 's/${{ steps.versions.outputs.old_version }}/${{ steps.versions.outputs.new_version }}/' xcc/_version.py
+
+      - name: Bump version in changelog
+        run: |
+          next_release_version=${{ steps.versions.outputs.new_version }}
+          next_release_version=${next_release_version%-dev}
+
+          header="## Release ${next_release_version} (development release)
+
+          ### Contributors
+
+          This release contains contributions from (in alphabetical order):
+          "
+
+          printf '%s\n%s\n' "$header" "$(cat .github/CHANGELOG.md)" > .github/CHANGELOG.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: main
+          title: Post-release version bump to `${{ steps.versions.outputs.new_version }}`
+          body: >
+            This PR bumps the XCC version from `${{ steps.versions.outputs.old_version }}`
+            to `${{ steps.versions.outputs.new_version }}`.
+          commit-message: Bump version to `${{ steps.versions.outputs.new_version }}`
+          branch: post-release-version-bump
+          reviewers: doctorperceptron, mandrenkov

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -1,0 +1,41 @@
+name: Pre-Release Version Bump
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pre_release_version_bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Derive versions
+        id: versions
+        run: |
+          old_version=`grep -oP '(?<=__version__ = ").*(?=")' xcc/_version.py`
+          new_version=${old_version%-dev}
+
+          echo "::set-output name=old_version::$old_version"
+          echo "::set-output name=new_version::$new_version"
+
+      - name: Bump version in _version.py
+        run:
+          sed -i 's/${{ steps.versions.outputs.old_version }}/${{ steps.versions.outputs.new_version }}/' xcc/_version.py
+
+      - name: Bump version in changelog
+        run: |
+          sed -i 's/ (current release)//' .github/CHANGELOG.md
+          sed -i 's/ (development release)/ (current release)/' .github/CHANGELOG.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: main
+          title: Pre-release version bump to `${{ steps.versions.outputs.new_version }}`
+          body: >
+            This PR bumps the XCC version from `${{ steps.versions.outputs.old_version }}`
+            to `${{ steps.versions.outputs.new_version }}`.
+          commit-message: Bump version to `${{ steps.versions.outputs.new_version }}`
+          branch: pre-release-version-bump
+          reviewers: doctorperceptron, mandrenkov


### PR DESCRIPTION
**Context:**
To release a new version of the XCC, two PRs are required:
1. A pre-release PR to remove the `-dev` suffix from the current version.
2. A post-release PR to increment the minor version and add a `-dev` suffix.

**Description of the Change:**
* Added a separate GitHub Actions workflow for each of each PR mentioned above.
    * Each workflow updates the [changelog](.github/CHANGELOG.md) and modifies the Python package version specified in [_version.py](https://github.com/XanaduAI/xanadu-cloud-client/blob/main/xcc/_version.py).

**Benefits:**
* There is less friction for making new XCC releases.

**Possible Drawbacks:**
* Some releases (e.g., patch or major version upgrades) still require a manual PR.

**Related GitHub Issues:**
None.