### PR TITLE
Prepare for v0.2.1 release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Release 0.2.1 (current release)
 
+### New features since last release
+
+* Job results can now be retrieved without converting integers to `np.int64` objects.
+  [(#24)](https://github.com/XanaduAI/xanadu-cloud-client/pull/24)
+
+  ```python
+  import xcc
+
+  job = xcc.Job("<UUID>", xcc.Connection.load())
+
+  result = job.get_result(integer_overflow_protection=False)
+  ```
+
+### Improvements
+
+* The default HOST setting now points to `platform.xanadu.ai`.
+  [(#24)](https://github.com/XanaduAI/xanadu-cloud-client/pull/24)
+
 ### Documentation
 
 * The centralized [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### New features since last release
 
 * Job results can now be retrieved without converting integers to `np.int64` objects.
-  [(#24)](https://github.com/XanaduAI/xanadu-cloud-client/pull/24)
+  [(#28)](https://github.com/XanaduAI/xanadu-cloud-client/pull/28)
 
   ```python
   import xcc
@@ -16,7 +16,7 @@
 ### Improvements
 
 * The default HOST setting now points to `platform.xanadu.ai`.
-  [(#24)](https://github.com/XanaduAI/xanadu-cloud-client/pull/24)
+  [(#28)](https://github.com/XanaduAI/xanadu-cloud-client/pull/28)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Release 0.3.0 (development release)
+## Release 0.2.1 (current release)
 
 ### Documentation
 
@@ -12,7 +12,7 @@ This release contains contributions from (in alphabetical order):
 
 [Mikhail Andrenkov](https://github.com/Mandrenkov).
 
-## Release 0.2.0 (current release)
+## Release 0.2.0
 
 ### New features since last release
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import xcc
 @pytest.fixture
 def connection() -> xcc.Connection:
     """Returns a mock connection."""
-    return xcc.Connection(refresh_token="j.w.t", host="cloud.xanadu.ai", port=443, tls=True)
+    return xcc.Connection(refresh_token="j.w.t", host="test.xanadu.ai", port=443, tls=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -71,8 +71,8 @@ class MockJob(xcc.Job):
     def language(self):
         return "blackbird:1.0"
 
-    def get_result(self, integer_overflow_protection):
-        return {"output": np.zeros((4, 4))}
+    def get_result(self, integer_overflow_protection=True):
+        return {"output": [np.zeros((4, 4))]}
 
     def cancel(self):
         pass
@@ -265,7 +265,7 @@ class TestGetJob:
     def test_result(self):
         """Tests that the result of a job can be retrieved."""
         have_result = xcc.commands.get_job(id="foo", result=True)
-        want_result = json.dumps({"output": str(np.zeros((4, 4)))}, indent=4)
+        want_result = json.dumps({"output": [str(np.zeros((4, 4)))]}, indent=4)
         assert have_result == want_result
 
     def test_invalid_number_of_flags(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -71,8 +71,7 @@ class MockJob(xcc.Job):
     def language(self):
         return "blackbird:1.0"
 
-    @cached_property
-    def result(self):
+    def get_result(self, integer_overflow_protection):
         return {"output": np.zeros((4, 4))}
 
     def cancel(self):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -87,7 +87,7 @@ class TestConnection:
 
     def test_host(self, connection):
         """Tests that the correct host is returned for a connection."""
-        assert connection.host == "cloud.xanadu.ai"
+        assert connection.host == "test.xanadu.ai"
 
     def test_port(self, connection):
         """Tests that the correct port is returned for a connection."""
@@ -118,14 +118,14 @@ class TestConnection:
     def test_repr(self, connection):
         """Tests that the printable representation of a connection is correct."""
         assert repr(connection) == (
-            "<Connection: refresh_token=j.w.t, access_token=None, url=https://cloud.xanadu.ai:443/>"
+            "<Connection: refresh_token=j.w.t, access_token=None, url=https://test.xanadu.ai:443/>"
         )
 
     def test_url(self, connection):
         """Tests that the correct URL is derived for a connection path."""
-        assert connection.url() == "https://cloud.xanadu.ai:443/"
-        assert connection.url("/") == "https://cloud.xanadu.ai:443/"
-        assert connection.url("/path/to/thing") == "https://cloud.xanadu.ai:443/path/to/thing"
+        assert connection.url() == "https://test.xanadu.ai:443/"
+        assert connection.url("/") == "https://test.xanadu.ai:443/"
+        assert connection.url("/path/to/thing") == "https://test.xanadu.ai:443/path/to/thing"
 
     @responses.activate
     def test_ping_success(self, connection):
@@ -253,7 +253,7 @@ class TestConnection:
 
         monkeypatch.setattr("xcc.connection.requests.request", mock_request)
 
-        match = r"GET request to 'https://cloud.xanadu.ai:443/healthz' timed out"
+        match = r"GET request to 'https://test.xanadu.ai:443/healthz' timed out"
         with pytest.raises(RequestException, match=match):
             connection.request("GET", "/healthz")
 
@@ -268,7 +268,7 @@ class TestConnection:
 
         monkeypatch.setattr("xcc.connection.requests.request", mock_request)
 
-        with pytest.raises(RequestException, match=r"Failed to resolve hostname 'cloud.xanadu.ai'"):
+        with pytest.raises(RequestException, match=r"Failed to resolve hostname 'test.xanadu.ai'"):
             connection.request("GET", "/healthz")
 
     @responses.activate

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -302,6 +302,33 @@ class TestJob:
         assert repr(job) == f"<Job: id={job.id}>"
 
     @responses.activate
+    def test_get_result_without_integer_overflow_protection(self, connection, job):
+        """Tests that the conversion of NumPy integers into ``np.int64`` objects
+        while retrieving a job result can be disabled.
+        """
+        output = [np.uint8(1), np.int16(2), np.int32(3)]
+
+        with io.BytesIO() as buffer:
+            # The public savez() function does not allow pickling to be disabled.
+            savez = numpy.lib.npyio._savez  # pylint: disable=protected-access
+            savez(file=buffer, args=output, kwds={}, compress=False, allow_pickle=False)
+
+            buffer.seek(0)
+            body = buffer.read()
+
+            path = f"/jobs/{job.id}/result"
+            responses.add(responses.GET, connection.url(path), status=200, body=body)
+
+            result = job.get_result(integer_overflow_protection=False)
+
+        assert result.keys() == {"output"}
+        assert result["output"] == pytest.approx([1, 2, 3])
+        assert result["output"][0].dtype == np.uint8
+        assert result["output"][1].dtype == np.int16
+        assert result["output"][2].dtype == np.int32
+
+
+    @responses.activate
     def test_cancel(self, connection, job, add_response):
         """Tests that a job can be cancelled."""
         add_response(body={"status": "open"})

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -303,8 +303,8 @@ class TestJob:
 
     @responses.activate
     def test_get_result_without_integer_overflow_protection(self, connection, job):
-        """Tests that the conversion of NumPy integers into ``np.int64`` objects
-        while retrieving a job result can be disabled.
+        """Tests that the result of a job can be retrieved without converting
+        integral entries into ``np.int64`` objects.
         """
         output = [np.uint8(1), np.int16(2), np.int32(3)]
 
@@ -326,7 +326,6 @@ class TestJob:
         assert result["output"][0].dtype == np.uint8
         assert result["output"][1].dtype == np.int16
         assert result["output"][2].dtype == np.int32
-
 
     @responses.activate
     def test_cancel(self, connection, job, add_response):

--- a/xcc/_version.py
+++ b/xcc/_version.py
@@ -3,4 +3,4 @@ This module specifies the XCC version number (<major>.<minor>.<patch>[-<pre-rele
 See https://semver.org/.
 """
 
-__version__ = "0.3.0-dev"
+__version__ = "0.2.1"

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -251,7 +251,7 @@ def get_job(
     if status:
         return job.status
     if result:
-        return job.result
+        return job.get_result(integer_overflow_protection=False)
 
     return job.overview
 

--- a/xcc/connection.py
+++ b/xcc/connection.py
@@ -107,7 +107,7 @@ class Connection:
         self,
         refresh_token: Optional[str] = None,
         access_token: Optional[str] = None,
-        host: str = "platform.strawberryfields.ai",
+        host: str = "platform.xanadu.ai",
         port: int = 443,
         tls: bool = True,
         headers: Optional[Dict[str, str]] = None,

--- a/xcc/device.py
+++ b/xcc/device.py
@@ -38,7 +38,7 @@ class Device:
     connection is established to the Xanadu Cloud:
 
     >>> import xcc
-    >>> connection = xcc.Connection(refresh_token="Xanadu Cloud API key goes here")
+    >>> connection = xcc.Connection.load()
 
     Next, a reference to the ``X8_01`` device is created using the connection.
 

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -183,45 +183,18 @@ class Job:
 
         Returns:
             Mapping[str, Union[np.ndarray, List[np.ndarray]]]: The result of
-            this job. Each job result has an "output" key associated with a list
-            of NumPy arrays representing the output of the job; all other keys
-            represent metadata related to the interpretation of the job output.
+            this job.
 
-        Raises:
-            TypeError: if the job result is not stored in the .npz file format
+        .. seealso::
+
+            Implemented in terms of :meth:`Job.get_result`.
+
+        .. note::
+
+            NumPy integers will be converted to ``np.int64`` objects to
+            facilitate safer post-processing.
         """
-        # Streaming the response in chunks is necessary to fetch large results.
-        response = self._connection.request("GET", f"/jobs/{self.id}/result", stream=True)
-
-        with io.BytesIO() as buffer:
-            # The chunk size below (i.e., 2^15 bytes) is less than the maximum
-            # size of a TCP packet (i.e., 2^16 bytes) but is otherwise arbitrary.
-            for chunk in response.iter_content(chunk_size=32768):
-                buffer.write(chunk)
-
-            # Seeking to 0 prepares the buffer for reading.
-            buffer.seek(0)
-
-            result = np.load(buffer, allow_pickle=False)
-
-            if not isinstance(result, np.lib.npyio.NpzFile):
-                raise TypeError("Job result is not an .npz file")
-
-            result = dict(result)
-
-        # Convert integral entries to int64 to avoid surprises during post-processing.
-        for key, array in result.items():
-            if np.issubdtype(array.dtype, np.integer):
-                result[key] = array.astype(np.int64)
-
-        # For convenience, move all positional arguments (i.e., those that have
-        # an "arr_" prefix) to a separate key named "output".
-        result["output"] = []
-        for i in takewhile(lambda i: f"arr_{i}" in result, count()):
-            array = result.pop(f"arr_{i}")
-            result["output"].append(array)
-
-        return result
+        return self.get_result(integer_overflow_protection=True)
 
     @property
     def created_at(self) -> datetime:
@@ -363,6 +336,64 @@ class Job:
     def __repr__(self) -> str:
         """Returns a printable representation of a job."""
         return f"<{self.__class__.__name__}: id={self.id}>"
+
+    def get_result(
+        self,
+        integer_overflow_protection: bool = True,
+    ) -> Mapping[str, Union[np.ndarray, List[np.ndarray]]]:
+        """Returns the result of a job.
+
+        Args:
+            integer_overflow_protection (bool): convert all NumPy integers into
+                64-bit NumPy integers to avoid surprises during post-processing;
+                setting this option to ``False`` can significantly reduce memory
+                consumption
+
+        Returns:
+            Mapping[str, Union[np.ndarray, List[np.ndarray]]]: The result of
+            this job. Each job result has an "output" key associated with a list
+            of NumPy arrays representing the output of the job; all other keys
+            represent metadata related to the interpretation of the job output.
+
+        Raises:
+            TypeError: if the job result is not stored in the .npz file format
+
+        .. warning::
+
+            The value returned by this method is not cached.
+        """
+        # Streaming the response in chunks is necessary to fetch large results.
+        response = self._connection.request("GET", f"/jobs/{self.id}/result", stream=True)
+
+        with io.BytesIO() as buffer:
+            # The chunk size below (i.e., 2^15 bytes) is less than the maximum
+            # size of a TCP packet (i.e., 2^16 bytes) but is otherwise arbitrary.
+            for chunk in response.iter_content(chunk_size=32768):
+                buffer.write(chunk)
+
+            # Seeking to 0 prepares the buffer for reading.
+            buffer.seek(0)
+
+            result = np.load(buffer, allow_pickle=False)
+
+            if not isinstance(result, np.lib.npyio.NpzFile):
+                raise TypeError("Job result is not an .npz file")
+
+            result = dict(result)
+
+        if integer_overflow_protection:
+            for key, array in result.items():
+                if np.issubdtype(array.dtype, np.integer):
+                    result[key] = array.astype(np.int64)
+
+        # For convenience, move all positional arguments (i.e., those that have
+        # an "arr_" prefix) to a separate key named "output".
+        result["output"] = []
+        for i in takewhile(lambda i: f"arr_{i}" in result, count()):
+            array = result.pop(f"arr_{i}")
+            result["output"].append(array)
+
+        return result
 
     def cancel(self) -> None:
         """Cancels a job."""

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -88,7 +88,7 @@ class Job:
        [0, 0, 0, 0],
        [0, 0, 0, 0]])]}
     >>> job.running_time
-    datetime.timedelta(microseconds=178768)
+    datetime.timedelta(microseconds=123456)
     """
 
     @staticmethod

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -345,9 +345,9 @@ class Job:
 
         Args:
             integer_overflow_protection (bool): convert all NumPy integers into
-                64-bit NumPy integers to avoid surprises during post-processing;
-                setting this option to ``False`` can significantly reduce memory
-                consumption
+                64-bit NumPy integers during post-processing; setting this
+                option to ``False`` can significantly reduce memory consumption
+                at the risk of introducing bugs during e.g. cubing operations
 
         Returns:
             Mapping[str, Union[np.ndarray, List[np.ndarray]]]: The result of

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -43,7 +43,7 @@ class Job:
     established to the Xanadu Cloud:
 
     >>> import xcc
-    >>> connection = xcc.Connection(refresh_token="Xanadu Cloud API key goes here")
+    >>> connection = xcc.Connection.load()
 
     Next, the parameters of the desired job are prepared. At present, this
     includes the name, target, circuit, and language of the job:
@@ -56,7 +56,7 @@ class Job:
             name {name}
             version 1.0
             target {target} (shots=3)
-            MeasureFock() | [0, 1, 2, 3];
+            MeasureFock() | [0, 1, 2, 3]
             \"\"\"
         )
     >>> language = "blackbird:1.0"
@@ -84,11 +84,11 @@ class Job:
     >>> job.status
     'complete'
     >>> job.result
-    array([[0, 0, 0, 0],
-           [0, 0, 0, 0],
-           [0, 0, 0, 0]], dtype=uint64)
+    {'output': [array([[0, 0, 0, 0],
+       [0, 0, 0, 0],
+       [0, 0, 0, 0]])]}
     >>> job.running_time
-    0.123456
+    datetime.timedelta(microseconds=178768)
     """
 
     @staticmethod

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
     >>> import xcc
     >>> settings = xcc.Settings()
     >>> settings
-    REFRESH_TOKEN=None ACCESS_TOKEN=None HOST='platform.strawberryfields.ai' PORT=443 TLS=True
+    REFRESH_TOKEN=None ACCESS_TOKEN=None HOST='platform.xanadu.ai' PORT=443 TLS=True
 
     Now, individual options can be accessed or assigned through their
     corresponding attribute:
@@ -73,7 +73,7 @@ class Settings(BaseSettings):
     ACCESS_TOKEN: Optional[str] = None
     """JWT access token that can be used to authenticate requests to the Xanadu Cloud."""
 
-    HOST: str = "platform.strawberryfields.ai"
+    HOST: str = "platform.xanadu.ai"
     """Hostname of the Xanadu Cloud server."""
 
     PORT: int = 443


### PR DESCRIPTION
**Context:**

A new patch release of the XCC is required to support some upcoming Xanadu Cloud milestones.

**Description of the Change:**

* Switched the default value of the HOST setting to `platform.xanadu.ai` (was `platform.strawberryfields.ai`).
* Added a flag to _disable_ the conversion of integral job results into `np.int64` objects.
* Updated the Device and Job class docstring examples to better reflect the current state of the XCC.
* Bumped the Python package version to v0.2.1.

**Benefits:**
* The new Xanadu Cloud domain is more widely advertised.
* The memory footprint of jobs that request many shots is significantly reduced.

**Possible Drawbacks:**
* Users are more prone to integer overflow errors if they explicitly disable the flag when retrieving job results.

**Related GitHub Issues:**
None.