### PR TITLE
Add status parameter to filter jobs 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -40,7 +40,7 @@ This release contains contributions from (in alphabetical order):
 
 ### New features since last release
 
-* Job lists can now be filtered by status.
+* Job lists can now be filtered by status as well.
   [(#30)](https://github.com/XanaduAI/xanadu-cloud-client/pull/30)
 
   Using the CLI:

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Release 0.3.0 (development release)
+
 ### New features since last release
 
 * Job lists can now be filtered by status.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -40,6 +40,21 @@ This release contains contributions from (in alphabetical order):
 
 ### New features since last release
 
+* Job lists can now be filtered by status as well.
+  [(#30)](https://github.com/XanaduAI/xanadu-cloud-client/pull/30)
+
+  Using the CLI:
+
+  ```bash
+  xcc job list --status '<status>'
+  ```
+
+  Using the Python API:
+
+   ```python
+  xcc.Job.list(connection, status='<status>')
+  ```
+
 * The Connection class can now load a Connection from a Settings instance.
   [(#22)](https://github.com/XanaduAI/xanadu-cloud-client/pull/22)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -40,7 +40,7 @@ This release contains contributions from (in alphabetical order):
 
 ### New features since last release
 
-* Job lists can now be filtered by status as well.
+* Job lists can now be filtered by status.
   [(#30)](https://github.com/XanaduAI/xanadu-cloud-client/pull/30)
 
   Using the CLI:

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,27 @@
 ## Release 0.3.0 (development release)
+### New features since last release
+
+* Job lists can now be filtered by status.
+  [(#30)](https://github.com/XanaduAI/xanadu-cloud-client/pull/30)
+
+  Using the CLI:
+
+  ```bash
+  xcc job list --status '<Status>'
+  ```
+
+  Using the Python API:
+
+   ```python
+  xcc.Job.list(connection, status="<Status>")
+  ```
+
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Hudhayfa Zaheem](https://github.com/HudZah).
 
 ## Release 0.2.1 (current release)
 
@@ -37,23 +56,6 @@ This release contains contributions from (in alphabetical order):
 [Mikhail Andrenkov](https://github.com/Mandrenkov).
 
 ## Release 0.2.0
-
-### New features since last release
-
-* Job lists can now be filtered by status as well.
-  [(#30)](https://github.com/XanaduAI/xanadu-cloud-client/pull/30)
-
-  Using the CLI:
-
-  ```bash
-  xcc job list --status '<status>'
-  ```
-
-  Using the Python API:
-
-   ```python
-  xcc.Job.list(connection, status='<status>')
-  ```
 
 * The Connection class can now load a Connection from a Settings instance.
   [(#22)](https://github.com/XanaduAI/xanadu-cloud-client/pull/22)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,9 +59,7 @@ primary_domain = "py"
 # Tell sphinx what the pygments highlight language should be.
 highlight_language = "py"
 
-mathjax_path = (
-    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
-)
+mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
 nbsphinx_requirejs_path = ""
 
 # Add any paths that contain templates here, relative to this directory.
@@ -85,6 +83,7 @@ author = "Xanadu Inc."
 #
 # The full version, including alpha/beta/rc tags.
 import xcc
+
 release = xcc.__version__
 
 # The short X.Y version.
@@ -253,7 +252,6 @@ html_theme = "xanadu"
 html_theme_options = {
     "navbar_name": "Xanadu Cloud Client",
     "navbar_logo_colour": "#78909c",
-
     "navbar_right_links": [
         {
             "name": "GitHub",
@@ -261,14 +259,12 @@ html_theme_options = {
             "icon": "fab fa-github",
         }
     ],
-
     "border_colour": "#78909c",
     "prev_next_button_colour": "#607d8b",
     "prev_next_button_hover_colour": "#34515e",
     "toc_marker_colour": "#78909c",
     "table_header_background_colour": "#78909c",
     "text_accent_colour": "#78909c",
-
 }
 
 edit_on_github_project = "XanaduAI/xanadu-cloud-client"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,9 @@ primary_domain = "py"
 # Tell sphinx what the pygments highlight language should be.
 highlight_language = "py"
 
-mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
+mathjax_path = (
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
+    )
 nbsphinx_requirejs_path = ""
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ version = re.match(r"\d+\.\d+", release).group(0)
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = "en"
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ highlight_language = "py"
 
 mathjax_path = (
     "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
-    )
+)
 nbsphinx_requirejs_path = ""
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ version = re.match(r"\d+\.\d+", release).group(0)
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@ docutils
 m2r2
 nbsphinx
 sphinx-copybutton
-sphinx>=3.1.0
+sphinx==4.5.0
 xanadu-sphinx-theme==0.1.0
+traitlets==5.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ m2r2
 nbsphinx
 sphinx-copybutton
 Jinja2<3.1
-sphinx<5.0.0
+sphinx<=4.5.0
 xanadu-sphinx-theme==0.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ m2r2
 nbsphinx
 sphinx-copybutton
 Jinja2<3.1
-sphinx<=4.5.0
+sphinx==4.5.0
 xanadu-sphinx-theme==0.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ docutils
 m2r2
 nbsphinx
 sphinx-copybutton
-sphinx<5.0.0
+sphinx<=4.5.0
 xanadu-sphinx-theme==0.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ docutils
 m2r2
 nbsphinx
 sphinx-copybutton
-sphinx==4.5.0
+sphinx<5.0.0
 xanadu-sphinx-theme==0.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ docutils
 m2r2
 nbsphinx
 sphinx-copybutton
-sphinx>=3.1.0
+sphinx==4.5.0
 xanadu-sphinx-theme==0.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ docutils
 m2r2
 nbsphinx
 sphinx-copybutton
-sphinx==4.5.0
+sphinx>=3.1.0
 xanadu-sphinx-theme==0.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@ docutils
 m2r2
 nbsphinx
 sphinx-copybutton
-sphinx<=4.5.0
+Jinja2<3.1
+sphinx<5.0.0
 xanadu-sphinx-theme==0.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ nbsphinx
 sphinx-copybutton
 sphinx==4.5.0
 xanadu-sphinx-theme==0.1.0
+traitlets==5.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,3 @@ nbsphinx
 sphinx-copybutton
 sphinx==4.5.0
 xanadu-sphinx-theme==0.1.0
-traitlets==5.2.0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -47,7 +47,7 @@ class MockJob(xcc.Job):
     """
 
     @staticmethod
-    def list(connection, limit=10, ids=None):
+    def list(connection, limit=10, ids=None, status= None):
         connection = xcc.commands.load_connection()
         return [MockJob(id_, connection) for id_ in ("foo", "bar", "baz")][:limit]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -47,7 +47,7 @@ class MockJob(xcc.Job):
     """
 
     @staticmethod
-    def list(connection, limit=10, ids=None, status= None):
+    def list(connection, limit=10, ids=None, status=None):
         connection = xcc.commands.load_connection()
         return [MockJob(id_, connection) for id_ in ("foo", "bar", "baz")][:limit]
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -134,8 +134,8 @@ class TestJob:
     )
     @responses.activate
     def test_list_status(self, connection, add_response, limit, status, want_status_param):
-        """Tests that the correct jobs are listed and that the correct status
-        parameter is encoded in the HTTP request to the Xanadu Cloud platform.
+        """Tests that the correct status parameter is encoded in the HTTP
+        request to the Xanadu Cloud platform when listing jobs.
         """
         add_response(body={"data": []}, path="/jobs")
         xcc.Job.list(connection, limit=limit, status=status)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -127,17 +127,9 @@ class TestJob:
         "limit, status, want_status_param",
         [
             (1, "queued", "queued"),
-            (
-                2,
-                None,
-                None,
-            ),
+            (2, None, None),
             (2, "invalid", "invalid"),
-            (
-                2,
-                "complete",
-                "complete",
-            ),
+            (2, "complete", "complete"),
         ],
     )
     @responses.activate

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -136,7 +136,7 @@ class TestJob:
             (
                 2,
                 None,
-                "",
+                None,
                 {"size": "2"},
                 ["foo", "bar"],
             ),
@@ -195,10 +195,15 @@ class TestJob:
         ][:limit]
 
         add_response(body={"data": data}, path="/jobs")
+        if status is not None:
+            have_names = [
+                job.name
+                for job in xcc.Job.list(connection, limit=limit, ids=ids, status=status)
+                if status is not None and job.status == status
+            ]
+        else:
+            have_names = [job.name for job in xcc.Job.list(connection, limit=limit, ids=ids)]
 
-        have_names = [
-            job.name for job in xcc.Job.list(connection, limit=limit, ids=ids, status=status)
-        ]
         assert have_names == want_names
 
         have_params = responses.calls[0].request.params  # pyright: reportGeneralTypeIssues=false

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -124,30 +124,24 @@ class TestJob:
         assert have_params == want_params
 
     @pytest.mark.parametrize(
-        "limit, ids, status, want_status_param",
+        "limit, status, want_status_param",
         [
-            (1, None, "queued", "queued"),
+            (1, "queued", "queued"),
             (
                 2,
-                None,
                 None,
                 None,
             ),
-            (2, None, "invalid", "invalid"),
+            (2, "invalid", "invalid"),
             (
                 2,
-                [
-                    "00000000-0000-0000-0000-000000000001",
-                    "00000000-0000-0000-0000-000000000002",
-                    "00000000-0000-0000-0000-000000000003",
-                ],
                 "complete",
                 "complete",
             ),
         ],
     )
     @responses.activate
-    def test_list_status(self, connection, add_response, limit, ids, status, want_status_param):
+    def test_list_status(self, connection, add_response, limit, status, want_status_param):
         """Tests that the correct jobs are listed and that the correct status
         parameter is encoded in the HTTP request to the Xanadu Cloud platform.
         """

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -257,18 +257,19 @@ def get_job(
 
 
 @beautify
-def list_jobs(limit: int = 5, ids: List[str] = None) -> Sequence[Mapping]:
+def list_jobs(limit: int = 5, ids: List[str] = None, status: str = None) -> Sequence[Mapping]:
     """Lists jobs submitted to the Xanadu Cloud.
 
     Args:
         limit (int): Maximum number of jobs to display.
         ids (List[str], optional): IDs of the jobs to display. If at least one
             ID is specified, the limit flag will be set to the number of IDs.
+        status (str): Status parameter used to filter returned jobs based on given status. 
 
     Returns:
         Sequence[Mapping]: Overview of each job submitted to the Xanadu Cloud.
     """
-    jobs = Job.list(connection=load_connection(), limit=limit, ids=ids)
+    jobs = Job.list(connection=load_connection(), limit=limit, ids=ids, status=status)
     return [job.overview for job in jobs]
 
 

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -264,7 +264,7 @@ def list_jobs(limit: int = 5, ids: List[str] = None, status: str = None) -> Sequ
         limit (int): Maximum number of jobs to display.
         ids (List[str], optional): IDs of the jobs to display. If at least one
             ID is specified, the limit flag will be set to the number of IDs.
-        status (str): Status parameter used to filter returned jobs based on given status.
+        status (str, optional): If specificed, filter returned jobs by the given status.
 
     Returns:
         Sequence[Mapping]: Overview of each job submitted to the Xanadu Cloud.

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -264,7 +264,7 @@ def list_jobs(limit: int = 5, ids: List[str] = None, status: str = None) -> Sequ
         limit (int): Maximum number of jobs to display.
         ids (List[str], optional): IDs of the jobs to display. If at least one
             ID is specified, the limit flag will be set to the number of IDs.
-        status (str): Status parameter used to filter returned jobs based on given status. 
+        status (str): Status parameter used to filter returned jobs based on given status.
 
     Returns:
         Sequence[Mapping]: Overview of each job submitted to the Xanadu Cloud.

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -97,7 +97,7 @@ class Job:
         connection: Connection, 
         limit: int = 5, 
         ids: Optional[Collection[str]] = None,
-        test: str = None
+        status: str = None
     ) -> Sequence[Job]:
         """Returns jobs submitted to the Xanadu Cloud.
 
@@ -108,16 +108,16 @@ class Job:
             ids (Collection[str], optional): IDs of the jobs to retrieve; if at
                 least one ID is specified, ``limit`` will be set to the length
                 of the ID collection
-            status (str): optional status parameter used to filter the jobs list. 
+            status (str, optional): status parameter used to filter the jobs list. 
                 If status is empty, return all the jobs 
 
         Returns:
             Sequence[Job]: jobs which were submitted on the Xanadu Cloud by the
             user associated with the Xanadu Cloud connection
         """
-        size = len(ids) if ids else limit # fix this to find all jobs instead. 
-        # size = len(ids)
-        response = connection.request("GET", "/jobs", params={"size": size, "id": ids})
+        size = len(ids) if ids else limit 
+
+        response = connection.request("GET", "/jobs", params={"size": size, "id": ids, "status": status})
 
         jobs = []
 
@@ -126,9 +126,8 @@ class Job:
             job._details = details  # pylint: disable=protected-access
             jobs.append(job)
 
-        filtered_jobs = list(filter(lambda job: (job.status == test), jobs))
+        return jobs
 
-        return filtered_jobs if test else jobs
 
     @staticmethod
     def submit(

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -118,7 +118,6 @@ class Job:
         params = {"size": size, "id": ids, "status": status}
         response = connection.request("GET", "/jobs", params=params)
 
-        print(response.url)
         jobs = []
 
         for details in response.json()["data"]:

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -5,7 +5,6 @@ This module contains the :class:`~xcc.Job` class.
 from __future__ import annotations
 
 import io
-from os import stat
 import time
 from datetime import datetime, timedelta
 from itertools import count, takewhile
@@ -94,10 +93,10 @@ class Job:
 
     @staticmethod
     def list(
-        connection: Connection, 
-        limit: int = 5, 
+        connection: Connection,
+        limit: int = 5,
         ids: Optional[Collection[str]] = None,
-        status: str = None
+        status: str = None,
     ) -> Sequence[Job]:
         """Returns jobs submitted to the Xanadu Cloud.
 
@@ -108,16 +107,18 @@ class Job:
             ids (Collection[str], optional): IDs of the jobs to retrieve; if at
                 least one ID is specified, ``limit`` will be set to the length
                 of the ID collection
-            status (str, optional): status parameter used to filter the jobs list. 
-                If status is empty, return all the jobs 
+            status (str, optional): status parameter used to filter the jobs list.
+                If status is empty, return all the jobs
 
         Returns:
             Sequence[Job]: jobs which were submitted on the Xanadu Cloud by the
             user associated with the Xanadu Cloud connection
         """
-        size = len(ids) if ids else limit 
+        size = len(ids) if ids else limit
 
-        response = connection.request("GET", "/jobs", params={"size": size, "id": ids, "status": status})
+        response = connection.request(
+            "GET", "/jobs", params={"size": size, "id": ids, "status": status}
+        )
 
         jobs = []
 
@@ -126,12 +127,17 @@ class Job:
             job._details = details  # pylint: disable=protected-access
             jobs.append(job)
 
-        return jobs
+        filtered_jobs = list(filter(lambda job: (job.status == status), jobs))
 
+        return filtered_jobs if status else jobs
 
     @staticmethod
     def submit(
-        connection: Connection, name: Optional[str], target: str, circuit: str, language: str
+        connection: Connection,
+        name: Optional[str],
+        target: str,
+        circuit: str,
+        language: str,
     ) -> Job:
         """Submits a job to the Xanadu Cloud.
 
@@ -145,7 +151,12 @@ class Job:
         Returns:
             Job: job submitted to the Xanadu Cloud
         """
-        payload = {"name": name, "target": target, "circuit": circuit, "language": language}
+        payload = {
+            "name": name,
+            "target": target,
+            "circuit": circuit,
+            "language": language,
+        }
         response = connection.request("POST", "/jobs", json=payload)
         details = response.json()
 

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -127,9 +127,7 @@ class Job:
             job._details = details  # pylint: disable=protected-access
             jobs.append(job)
 
-        filtered_jobs = list(filter(lambda job: (job.status == status), jobs))
-
-        return filtered_jobs if status else jobs
+        return jobs
 
     @staticmethod
     def submit(

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -5,6 +5,7 @@ This module contains the :class:`~xcc.Job` class.
 from __future__ import annotations
 
 import io
+from os import stat
 import time
 from datetime import datetime, timedelta
 from itertools import count, takewhile
@@ -93,9 +94,13 @@ class Job:
 
     @staticmethod
     def list(
-        connection: Connection, limit: int = 5, ids: Optional[Collection[str]] = None
+        connection: Connection, 
+        limit: int = 5, 
+        ids: Optional[Collection[str]] = None,
+        test: str = None
     ) -> Sequence[Job]:
         """Returns jobs submitted to the Xanadu Cloud.
+
 
         Args:
             connection (Connection): connection to the Xanadu Cloud
@@ -103,12 +108,15 @@ class Job:
             ids (Collection[str], optional): IDs of the jobs to retrieve; if at
                 least one ID is specified, ``limit`` will be set to the length
                 of the ID collection
+            status (str): optional status parameter used to filter the jobs list. 
+                If status is empty, return all the jobs 
 
         Returns:
             Sequence[Job]: jobs which were submitted on the Xanadu Cloud by the
             user associated with the Xanadu Cloud connection
         """
-        size = len(ids) if ids else limit
+        size = len(ids) if ids else limit # fix this to find all jobs instead. 
+        # size = len(ids)
         response = connection.request("GET", "/jobs", params={"size": size, "id": ids})
 
         jobs = []
@@ -118,7 +126,9 @@ class Job:
             job._details = details  # pylint: disable=protected-access
             jobs.append(job)
 
-        return jobs
+        filtered_jobs = list(filter(lambda job: (job.status == test), jobs))
+
+        return filtered_jobs if test else jobs
 
     @staticmethod
     def submit(

--- a/xcc/job.py
+++ b/xcc/job.py
@@ -96,7 +96,7 @@ class Job:
         connection: Connection,
         limit: int = 5,
         ids: Optional[Collection[str]] = None,
-        status: str = None,
+        status: Optional[str] = None,
     ) -> Sequence[Job]:
         """Returns jobs submitted to the Xanadu Cloud.
 
@@ -107,8 +107,7 @@ class Job:
             ids (Collection[str], optional): IDs of the jobs to retrieve; if at
                 least one ID is specified, ``limit`` will be set to the length
                 of the ID collection
-            status (str, optional): status parameter used to filter the jobs list.
-                If status is empty, return all the jobs
+            status (str, optional): filter jobs by the given status (if not ``None``)
 
         Returns:
             Sequence[Job]: jobs which were submitted on the Xanadu Cloud by the
@@ -116,10 +115,10 @@ class Job:
         """
         size = len(ids) if ids else limit
 
-        response = connection.request(
-            "GET", "/jobs", params={"size": size, "id": ids, "status": status}
-        )
+        params = {"size": size, "id": ids, "status": status}
+        response = connection.request("GET", "/jobs", params=params)
 
+        print(response.url)
         jobs = []
 
         for details in response.json()["data"]:


### PR DESCRIPTION
**Context:**
With this change users can filter the jobs by the `status` parameter that is passed to the `/ jobs` endpoint where the jobs are filtered and returned. 

**Description of the Change:**
- Added `status` parameter to the `xcc.Job.list()`
- Accepts the `status` parameter in the CLI as well by using the `--status` argument. 
- Added tests to ensure that it works as intended
```python
response = connection.request(
            "GET", "/jobs", params={"size": size, "id": ids, "status": status}
        )
```

**Benefits:**
- Easier filteration of jobs to view them solely based on the input status.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A