### PR TITLE
Safe refresh

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Improvements
 
-* An exception is now raised when saving a refresh token with unprintable characters.
+* An exception is now raised when saving a refresh token with invalid characters.
   [#31](https://github.com/XanaduAI/xanadu-cloud-client/pull/31)
 
 ### New features since last release

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
-* [Jack Woehr](https://github.com/jwoehr)
+
+[Jack Woehr](https://github.com/jwoehr)
 
 ## Release 0.2.1 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Release 0.3.0 (development release)
+* REFRESH_TOKEN entries that have unprintable characters should now raise.
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+* [Jack Woehr](https://github.com/jwoehr)
 
 ## Release 0.2.1 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Release 0.3.0 (development release)
 * REFRESH_TOKEN entries that have unprintable characters should now raise.
+  [#31](https://github.com/XanaduAI/xanadu-cloud-client/pull/31)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release 0.3.0 (development release)
-* REFRESH_TOKEN entries that have unprintable characters should now raise.
+
+### Improvements
+
+* An exception is now raised when saving a refresh token with unprintable characters.
   [#31](https://github.com/XanaduAI/xanadu-cloud-client/pull/31)
 
 ### Contributors

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -54,11 +54,30 @@ class TestSettings:
 
     def test_save(self, env_file):
         """Tests that settings can be saved to a .env file."""
-        settings = xcc.Settings(REFRESH_TOKEN="j.w.t", HOST="example.com", PORT=80, TLS=False)
+        settings = xcc.Settings(
+            REFRESH_TOKEN="j.w.t", HOST="example.com", PORT=80, TLS=False
+        )
         settings.save()
 
         assert dotenv_values(env_file.name) == {
             "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t",
+            "XANADU_CLOUD_HOST": "example.com",
+            "XANADU_CLOUD_PORT": "80",
+            "XANADU_CLOUD_TLS": "False",
+        }
+
+    def test_save_unprintable(self, env_file):
+        """Tests that settings won't be saved to a .env file
+        if REFRESH_TOKEN contains non_printables.
+        Note blank space at end of token below.
+        """
+        settings = xcc.Settings(
+            REFRESH_TOKEN="j.w.t ", HOST="example.com", PORT=80, TLS=False
+        )
+        settings.save()
+
+        assert dotenv_values(env_file.name) == {
+            "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t ",
             "XANADU_CLOUD_HOST": "example.com",
             "XANADU_CLOUD_PORT": "80",
             "XANADU_CLOUD_TLS": "False",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -66,26 +66,25 @@ class TestSettings:
             "XANADU_CLOUD_TLS": "False",
         }
 
-    def test_save_bad_Base64URL(self, env_file):
+    def test_save_bad_Base64URL(self, settings):
         """Tests that a ValueError will be raised
         if REFRESH_TOKEN contains a character outside the Base64URL with
         the addition that the '.' dot character is part of the token as a
         section separator.
         """
-        settings = xcc.Settings(
-            REFRESH_TOKEN="j.w.t\n", HOST="example.com", PORT=80, TLS=False
-        )
-        match = r"REFRESH_TOKEN contains non-Base64URL character\(s\)"
+        settings.REFRESH_TOKEN = "j.w.t\n"
+
+        match = r"REFRESH_TOKEN contains non-JWT character\(s\)"
         with pytest.raises(ValueError, match=match):
             settings.save()
 
-        # # Check that the .env file was not modified since there was a "\n" in the refresh token.
-        # assert dotenv_values(env_file.name) == {
-        #     "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t",
-        #     "XANADU_CLOUD_HOST": "example.com",
-        #     "XANADU_CLOUD_PORT": "80",
-        #     "XANADU_CLOUD_TLS": "False",
-        # }
+        # Check that the .env file was not modified since there was a "\n" in the refresh token.
+        assert dotenv_values(env_file.name) == {
+            "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t",
+            "XANADU_CLOUD_HOST": "example.com",
+            "XANADU_CLOUD_PORT": "80",
+            "XANADU_CLOUD_TLS": "False",
+        }
 
     def test_save_multiple_times(self, settings):
         """Tests that settings can be saved to a .env file multiple times."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -74,7 +74,9 @@ class TestSettings:
         settings = xcc.Settings(
             REFRESH_TOKEN="j.w.t ", HOST="example.com", PORT=80, TLS=False
         )
-        settings.save()
+        match = r"The REFRESH_TOKEN setting contains non-printable character(s)\."
+        with pytest.raises(ValueError, match=match):
+            settings.save()
 
         assert dotenv_values(env_file.name) == {
             "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t ",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -79,7 +79,7 @@ class TestSettings:
             settings.save()
 
         # Check that the .env file was not modified since there was a "\n" in the refresh token.
-        assert dotenv_values(env_file.name) == {
+        assert dotenv_values(xcc.Settings.Config.env_file) == {
             "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t",
             "XANADU_CLOUD_HOST": "example.com",
             "XANADU_CLOUD_PORT": "80",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -54,9 +54,7 @@ class TestSettings:
 
     def test_save(self, env_file):
         """Tests that settings can be saved to a .env file."""
-        settings = xcc.Settings(
-            REFRESH_TOKEN="j.w.t", HOST="example.com", PORT=80, TLS=False
-        )
+        settings = xcc.Settings(REFRESH_TOKEN="j.w.t", HOST="example.com", PORT=80, TLS=False)
         settings.save()
 
         assert dotenv_values(env_file.name) == {
@@ -66,7 +64,7 @@ class TestSettings:
             "XANADU_CLOUD_TLS": "False",
         }
 
-    def test_save_bad_Base64URL(self, settings):
+    def test_save_bad_base64_url(self, settings):
         """Tests that a ValueError will be raised
         if REFRESH_TOKEN contains a character outside the Base64URL with
         the addition that the '.' dot character is part of the token as a

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -67,7 +67,7 @@ class TestSettings:
         }
 
     def test_save_unprintable(self, env_file):
-        """Tests that settings won't be saved to a .env file
+        """Tests that a ValueError will be raised
         if REFRESH_TOKEN contains a non-printable character.
         Note blank space at end of token below.
         """

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -72,7 +72,7 @@ class TestSettings:
         Note blank space at end of token below.
         """
         settings = xcc.Settings(
-            REFRESH_TOKEN="j.w.t ", HOST="example.com", PORT=80, TLS=False
+            REFRESH_TOKEN="j.w.t\n", HOST="example.com", PORT=80, TLS=False
         )
         match = r"The REFRESH_TOKEN setting contains non-printable character(s)\."
         with pytest.raises(ValueError, match=match):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -79,6 +79,14 @@ class TestSettings:
         with pytest.raises(ValueError, match=match):
             settings.save()
 
+        # # Check that the .env file was not modified since there was a "\n" in the refresh token.
+        # assert dotenv_values(env_file.name) == {
+        #     "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t",
+        #     "XANADU_CLOUD_HOST": "example.com",
+        #     "XANADU_CLOUD_PORT": "80",
+        #     "XANADU_CLOUD_TLS": "False",
+        # }
+
     def test_save_multiple_times(self, settings):
         """Tests that settings can be saved to a .env file multiple times."""
         path_to_env_file = xcc.Settings.Config.env_file

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -68,7 +68,7 @@ class TestSettings:
 
     def test_save_unprintable(self, env_file):
         """Tests that settings won't be saved to a .env file
-        if REFRESH_TOKEN contains non_printables.
+        if REFRESH_TOKEN contains a non-printable character.
         Note blank space at end of token below.
         """
         settings = xcc.Settings(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -66,24 +66,18 @@ class TestSettings:
             "XANADU_CLOUD_TLS": "False",
         }
 
-    def test_save_unprintable(self, env_file):
+    def test_save_bad_Base64URL(self, env_file):
         """Tests that a ValueError will be raised
-        if REFRESH_TOKEN contains a non-printable character.
-        Note blank space at end of token below.
+        if REFRESH_TOKEN contains a character outside the Base64URL with
+        the addition that the '.' dot character is part of the token as a
+        section separator.
         """
         settings = xcc.Settings(
             REFRESH_TOKEN="j.w.t\n", HOST="example.com", PORT=80, TLS=False
         )
-        match = r"The REFRESH_TOKEN setting contains non-printable character(s)\."
+        match = r"REFRESH_TOKEN contains non-Base64URL character\(s\)"
         with pytest.raises(ValueError, match=match):
             settings.save()
-
-        assert dotenv_values(env_file.name) == {
-            "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t ",
-            "XANADU_CLOUD_HOST": "example.com",
-            "XANADU_CLOUD_PORT": "80",
-            "XANADU_CLOUD_TLS": "False",
-        }
 
     def test_save_multiple_times(self, settings):
         """Tests that settings can be saved to a .env file multiple times."""

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -94,7 +94,7 @@ class Settings(BaseSettings):
         env_file = get_path_to_env_file()
         env_prefix = get_name_of_env_var()
 
-    def _sanity_check(self, key: str, val: str) -> None:
+    def _check_for_invalid_values(self, key: str, val: str) -> None:
         """
         Check for conditions that make saving the env_file
         dangerous to the user.
@@ -126,8 +126,11 @@ class Settings(BaseSettings):
 
         saved = dotenv_values(dotenv_path=env_file)
 
+        # must be done first as dict is not ordered
         for key, val in self.dict().items():
-            self._sanity_check(key, val)
+            self._check_for_invalid_values(key, val)
+
+        for key, val in self.dict().items():
             field = get_name_of_env_var(key)
 
             # Remove keys that are assigned to None.

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -92,22 +92,12 @@ class Settings(BaseSettings):
         Check for conditions that make saving the env_file
         dangerous to the user.
 
-        Parameters
-        ----------
-        key : str
-            env file key
-        val : str
-            env file value
+        Args:
+            key (str): .env file key
+            val (str): .env file value
 
-        Raises
-        ------
-        Exception
-            When the value should not be saved to the env_file.
-
-        Returns
-        -------
-        None
-            Has no effect if all is safe.
+        Raises:
+            Exception: if the value should not be saved to the .env file
 
         """
         # Unprintables in REFRESH_TOKEN assumed never to be valid (0x0a, 0x20, etc.)

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -115,7 +115,7 @@ class Settings(BaseSettings):
             and val is not None
             and re.search(_BASE64URLRE, val) is not None
         ):
-            raise ValueError("REFRESH_TOKEN contains non-Base64URL character(s)")
+            raise ValueError("REFRESH_TOKEN contains non-JWT character(s)")
 
     def save(self) -> None:
         """Saves the current settings to the .env file."""

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -111,7 +111,8 @@ class Settings(BaseSettings):
 
         """
         # Unprintables in REFRESH_TOKEN assumed never to be valid (0x0a, 0x20, etc.)
-        if key == "REFRESH_TOKEN" and not val.isprintable():
+
+        if key == "REFRESH_TOKEN" and val is not None and not val.isprintable():
             raise Exception("REFRESH_TOKEN contains non-printable character(s)")
 
     def save(self) -> None:

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -113,7 +113,7 @@ class Settings(BaseSettings):
         # Unprintables in REFRESH_TOKEN assumed never to be valid (0x0a, 0x20, etc.)
 
         if key == "REFRESH_TOKEN" and val is not None and not val.isprintable():
-            raise Exception("REFRESH_TOKEN contains non-printable character(s)")
+            raise ValueError("REFRESH_TOKEN contains non-printable character(s)")
 
     def save(self) -> None:
         """Saves the current settings to the .env file."""

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -106,7 +106,7 @@ class Settings(BaseSettings):
             val (str): .env file value
 
         Raises:
-            Exception: if the value should not be saved to the .env file
+            ValueError: if the value should not be saved to the .env file
 
         """
 

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -125,7 +125,7 @@ class Settings(BaseSettings):
         saved = dotenv_values(dotenv_path=env_file)
 
         for key, val in self.dict().items():
-            self._sanity_check(key, val)  # check for obviously bad settings
+            self._sanity_check(key, val)
             field = get_name_of_env_var(key)
 
             # Remove keys that are assigned to None.


### PR DESCRIPTION
**Context:**
It's possible to save bad refresh tokens by accidentally including non-printable characters when copying them.

**Description of the Change:**
`Settings.save()` does a sanity check and `raise`s on unprintables in the refresh token.

**Benefits:**
Less surprise and mystery on a user error in performing a token refresh

**Possible Drawbacks:**
This works, but though I wrote a test, I have not been able to make the test work, could use some help on `test_settings.py` test `test_save_unprintable`

**Related GitHub Issues:**