### PR TITLE
Add toml file

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release 0.3.0 (development release)
 
 ### New features since last release
+* `pyproject.toml` file added with option for `[tool.black]` so all developers get the project-approved `black` settings
 
 * Job lists can now be filtered by status.
   [(#30)](https://github.com/XanaduAI/xanadu-cloud-client/pull/30)
@@ -13,7 +14,7 @@
 
   Using the Python API:
 
-   ```python
+  ```python
   xcc.Job.list(connection, status="<Status>")
   ```
 
@@ -22,6 +23,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+[Jack Woehr](https://githup.com/jwoehr)
 [Hudhayfa Zaheem](https://github.com/HudZah).
 
 ## Release 0.2.1 (current release)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Release 0.3.0 (development release)
 
 ### New features since last release
-* `pyproject.toml` file added with option for `[tool.black]` so all developers get the project-approved `black` settings
 
 * Job lists can now be filtered by status.
   [(#30)](https://github.com/XanaduAI/xanadu-cloud-client/pull/30)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint:
 
 .PHONY: format
 format:
-	$(PYTHON) -m black --check --diff --color -l 100 xcc tests
+	$(PYTHON) -m black --check --diff --color xcc tests
 	$(PYTHON) -m isort --check --diff --color --profile black xcc tests
 
 .PHONY: wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100


### PR DESCRIPTION
**Context:**
`make format` does a `black --check -l 100` which is not `black` default line length

**Description of the Change:**
Add a `pyproject.toml` file which sets `black` line length to 100.

**Benefits:**
Contributors running `black` on their contributions will get the results expected by `make format`.

**Possible Drawbacks:**
Contributors used to `black` defaults may at first be puzzled by the reformatted files.

**Related GitHub Issues:**
None.