### PR TITLE
Improve formatting of job results in CLI command

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,11 +22,36 @@
 * An exception is now raised when saving a refresh token with invalid characters.
   [#31](https://github.com/XanaduAI/xanadu-cloud-client/pull/31)
 
+* Job results are now displayed using the `pprint` module.
+  [#32](https://github.com/XanaduAI/xanadu-cloud-client/pull/32)
+
+  Before:
+
+  ```json
+  {
+      "output": [
+          "[[0 0 0 0]\n [0 0 0 0]\n [0 0 0 0]\n [0 0 0 0]\n [0 0 0 0]]"
+      ]
+  }
+  ```
+
+  After:
+
+  ```json
+  {
+      "output": [[[0, 0, 0, 0],
+                  [0, 0, 0, 0],
+                  [0, 0, 0, 0],
+                  [0, 0, 0, 0],
+                  [0, 0, 0, 0]]]
+  }
+  ```
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-[Jack Woehr](https://githup.com/jwoehr), [Hudhayfa Zaheem](https://github.com/HudZah).
+[Mikhail Andrenkov](https://github.com/Mandrenkov), [Jack Woehr](https://githup.com/jwoehr), [Hudhayfa Zaheem](https://github.com/HudZah).
 
 ## Release 0.2.1 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,7 +23,7 @@
   [#31](https://github.com/XanaduAI/xanadu-cloud-client/pull/31)
 
 * Job results are now displayed using the `pprint` module.
-  [#32](https://github.com/XanaduAI/xanadu-cloud-client/pull/32)
+  [#33](https://github.com/XanaduAI/xanadu-cloud-client/pull/33)
 
   Before:
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,6 +4,7 @@ This module tests the :module:`xcc.commands` module.
 """
 
 import json
+from inspect import cleandoc
 
 import numpy as np
 import pytest
@@ -72,7 +73,7 @@ class MockJob(xcc.Job):
         return "blackbird:1.0"
 
     def get_result(self, integer_overflow_protection=True):
-        return {"output": [np.zeros((4, 4))]}
+        return {"output": [np.zeros((4, 4))], "metadata": np.ones((2, 2))}
 
     def cancel(self):
         pass
@@ -265,7 +266,17 @@ class TestGetJob:
     def test_result(self):
         """Tests that the result of a job can be retrieved."""
         have_result = xcc.commands.get_job(id="foo", result=True)
-        want_result = json.dumps({"output": [str(np.zeros((4, 4)))]}, indent=4)
+        want_result = cleandoc(
+            """
+            {
+                "metadata": [[1.0, 1.0], [1.0, 1.0]],
+                "output": [[[0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0]]]
+            }
+            """
+        )
         assert have_result == want_result
 
     def test_invalid_number_of_flags(self):


### PR DESCRIPTION
**Context:**

NumPy arrays are currently displayed as _strings_ in the output of `xcc job get "<Job ID>" --result` commands. Consequently,
* Syntax highlighting for job results is misleading.
* Newline characters are not honoured during rendering.
* Large arrays are prone to exceeding the width of the terminal window.

For example,

```bash
xcc job get "919e84c9-01fd-4ba7-b2b3-7c1bdec49dd4" --result
```

yields

```json
{
    "output": [
        "[[0 0 0 0 0 0 0 0]\n [0 1 0 1 0 0 0 1]\n [0 0 1 2 0 0 0 1]\n [1 1 0 2 2 0 0 1]\n [0 0 1 0 1 0 0 0]\n [1 0 1 2 0 1 0 0]\n [0 0 0 1 0 0 0 0]\n [0 0 0 0 0 0 0 0]\n [0 1 0 2 0 0 0 1]\n [0 1 1 1 3 1 1 0]\n [0 0 0 1 0 0 1 1]\n [0 0 0 0 0 1 1 0]\n [0 0 0 1 0 1 0 1]\n [0 0 1 0 0 0 0 0]\n [0 1 0 0 2 0 1 1]\n [0 0 0 1 1 0 0 1]\n [0 0 0 0 1 0 1 0]\n [2 0 0 0 0 0 0 0]\n [1 1 1 0 2 0 0 2]\n [0 0 0 1 0 0 0 1]]"
    ]
}
```

**Description of the Change:**

* Used [`pformat()`](https://docs.python.org/3/library/pprint.html#pprint.pformat) to format NumPy arrays within the output of the `xcc job get "<Job ID>" --result` command.
* The example in the **Context** section now shows:

```json
{
    "output": [[[0, 0, 0, 0, 0, 0, 0, 0],
                [0, 1, 0, 1, 0, 0, 0, 1],
                [0, 0, 1, 2, 0, 0, 0, 1],
                [1, 1, 0, 2, 2, 0, 0, 1],
                [0, 0, 1, 0, 1, 0, 0, 0],
                [1, 0, 1, 2, 0, 1, 0, 0],
                [0, 0, 0, 1, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 1, 0, 2, 0, 0, 0, 1],
                [0, 1, 1, 1, 3, 1, 1, 0],
                [0, 0, 0, 1, 0, 0, 1, 1],
                [0, 0, 0, 0, 0, 1, 1, 0],
                [0, 0, 0, 1, 0, 1, 0, 1],
                [0, 0, 1, 0, 0, 0, 0, 0],
                [0, 1, 0, 0, 2, 0, 1, 1],
                [0, 0, 0, 1, 1, 0, 0, 1],
                [0, 0, 0, 0, 1, 0, 1, 0],
                [2, 0, 0, 0, 0, 0, 0, 0],
                [1, 1, 1, 0, 2, 0, 0, 2],
                [0, 0, 0, 1, 0, 0, 0, 1]]]
}
```

**Benefits:**

* Job results are displayed in a richer and more compact format which lends itself better to visual parsing.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

Resolves #33.