### PR TITLE
Allow passing extra headers to Connection.request

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,6 +4,7 @@ This module tests the :module:`xcc.connection` module.
 """
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 import requests
@@ -270,6 +271,30 @@ class TestConnection:
 
         with pytest.raises(RequestException, match=r"Failed to resolve hostname 'test.xanadu.ai'"):
             connection.request("GET", "/healthz")
+
+    def test_request_headers(self, connection):
+        """Test that request() passes the headers attribute to _request if the headers argument
+        is not provided."""
+
+        connection._request = MagicMock()
+        connection.request(method="method", path="path")
+
+        connection._request.assert_called_once_with(
+            method="method", url=connection.url("path"), headers=connection.headers
+        )
+
+    @pytest.mark.parametrize("extra_headers", [{"X-Test": "data"}, {}])
+    def test_request_extra_headers(self, connection, extra_headers):
+        """Tests that request() passes the combined headers from the headers attribute
+        and the headers argument to the _request method."""
+        connection._request = MagicMock()
+
+        connection.request(method="post", path="path", headers=extra_headers)
+        connection._request.assert_called_once_with(
+            method="post",
+            url=connection.url("path"),
+            headers={**connection.headers, **extra_headers},
+        )
 
     @responses.activate
     def test_update_access_token_success(self, connection):

--- a/xcc/connection.py
+++ b/xcc/connection.py
@@ -210,12 +210,15 @@ class Connection:
         """
         return self.request(method="GET", path="/healthz")
 
-    def request(self, method: str, path: str, **kwargs) -> requests.Response:
+    def request(
+        self, method: str, path: str, *, headers: Optional[Dict[str, str]] = None, **kwargs
+    ) -> requests.Response:
         """Sends an HTTP request to the Xanadu Cloud.
 
         Args:
             method (str): HTTP request method
             path (str): HTTP request path
+            headers (Mapping[str, str]): Extra headers to pass to request
             **kwargs: optional arguments to pass to :func:`requests.request()`
 
         Returns:
@@ -235,7 +238,12 @@ class Connection:
         """
         url = self.url(path)
 
-        response = self._request(method=method, url=url, headers=self.headers, **kwargs)
+        if headers:
+            headers = {**self.headers, **headers}
+        else:
+            headers = self.headers
+
+        response = self._request(method=method, url=url, headers=headers, **kwargs)
 
         if response.status_code == 401:
             self.update_access_token()


### PR DESCRIPTION
**Context:**
Cannot pass extra headers when using `Connection.request()`.

**Description of the Change:**
Adds an optional `headers` argument to `Connection.request()` and that is added to request
headers

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**