### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -16,8 +16,8 @@ jobs:
           old_version=`grep -oP '(?<=__version__ = ").*(?=")' xcc/_version.py`
           new_version=${old_version%-dev}
 
-          echo "::set-output name=old_version::$old_version"
-          echo "::set-output name=new_version::$new_version"
+          echo "old_version=$old_version" >> $GITHUB_OUTPUT
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
       - name: Bump version in _version.py
         run:


### PR DESCRIPTION
**Context:**
The `set-ouput` command is being removed by Github. 

**Description of the Change:**
The PR replaces that command with a write to the Github output env variable.

**Benefits:**
Actions will continue to work.

**Possible Drawbacks:**

**Related GitHub Issues:**