### PR TITLE
Pin compatible Pydantic versions to `<2`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 * Bumped `wheel` to v0.38.1. [(#39)](https://github.com/XanaduAI/xanadu-cloud-client/pull/39)
 
+### Bug fixes
+
+* Set upper bound on compatible `pydantic` versions to v2.0.0. [(#42)](https://github.com/XanaduAI/xanadu-cloud-client/pull/42)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
 
 ## Release 0.3.0 (current release)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [
     "appdirs",
     "fire",
     "numpy",
-    "pydantic[dotenv]",
+    "pydantic[dotenv]<2",
     "python-dateutil",
     "requests",
 ]


### PR DESCRIPTION
**Context:**

A few days ago, [Pydantic v2](https://docs.pydantic.dev/2.0/blog/pydantic-v2-final/) was released and included some breaking changes to its API. This PR updates the XCC package requirements to specify that Pydantic v2 is not currently supported.

**Description of the Change:**

* Placed an upper bound on the compatible Pydantic versions to `<2`.

**Benefits:**

* XCC installations in environments that do not explicitly require Pydantic v2 are no longer broken.

**Possible Drawbacks:**

None but eventually the XCC should be updated to support Pydantic v2.

**Related GitHub Issues:**

None.