### PR TITLE
Update pydantic to version 2.4

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,20 +1,14 @@
-## Release 0.4.1 (development release)
+## Release 0.3.2 (development release)
 
 ### Bug fixes
 
-* Updates required `pydantic` version from 1.8.2 to 2.4, while still continuing to use "v1" features. [#46](https://github.com/XanaduAI/xanadu-cloud-client/pull/46)
+* Sets lower bound on compatible `pydantic` versions to v2.0.0. [(#46)](https://github.com/XanaduAI/xanadu-cloud-client/pull/46)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-[Luke Helt](https://github.com/heltluke).
-
-## Release 0.4.0 (development release)
-
-### Contributors
-
-This release contains contributions from (in alphabetical order):
+[Mikhail Andrenkov](https://github.com/Mandrenkov), [Luke Helt](https://github.com/heltluke).
 
 ## Release 0.3.1 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Release 0.4.1 (development release)
+
+### Bug fixes
+
+* Updates required `pydantic` version from 1.8.2 to 2.4, while still continuing to use "v1" features. [#46](https://github.com/XanaduAI/xanadu-cloud-client/pull/46)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Luke Helt](https://github.com/heltluke).
+
 ## Release 0.4.0 (development release)
 
 ### Contributors

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Release 0.3.2 (development release)
+## Release 0.3.2 (current release)
 
 ### Bug fixes
 
@@ -10,7 +10,7 @@ This release contains contributions from (in alphabetical order):
 
 [Mikhail Andrenkov](https://github.com/Mandrenkov), [Luke Helt](https://github.com/heltluke).
 
-## Release 0.3.1 (current release)
+## Release 0.3.1
 
 ### Improvements
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.8"
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.8"
 
       - name: Install dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ python-dotenv==0.21.1
 fire==0.4.0
 numpy==1.21.3
 pydantic==2.4
+pydantic-settings==2.1.0
 python-dateutil==2.8.2
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 appdirs==1.4.4
-python-dotenv==0.21.1
 fire==0.4.0
 numpy==1.21.3
 pydantic==2.4
+pydantic-settings==2.1.0
 python-dateutil==2.8.2
+python-dotenv==0.21.1
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 appdirs==1.4.4
+python-dotenv==1.0.0
 fire==0.4.0
 numpy==1.21.3
-pydantic[dotenv]==1.8.2
+pydantic==2.4
 python-dateutil==2.8.2
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ python-dotenv==0.21.1
 fire==0.4.0
 numpy==1.21.3
 pydantic==2.4
-pydantic-settings==2.1.0
+pydantic-settings>=0.2.5
 python-dateutil==2.8.2
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ python-dotenv==0.21.1
 fire==0.4.0
 numpy==1.21.3
 pydantic==2.4
-pydantic-settings>=0.2.5
 python-dateutil==2.8.2
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.4
-python-dotenv==1.0.0
+python-dotenv==0.21.1
 fire==0.4.0
 numpy==1.21.3
 pydantic==2.4

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ requirements = [
     "fire",
     "numpy",
     "pydantic",
+    "pydantic-settings",
     "python-dateutil",
     "requests",
 ]

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,12 @@ with open("xcc/_version.py") as f:
 
 requirements = [
     "appdirs",
-    "python-dotenv",
     "fire",
     "numpy",
     "pydantic",
+    "pydantic-settings",
     "python-dateutil",
+    "python-dotenv",
     "requests",
 ]
 
@@ -42,7 +43,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ requirements = [
     "fire",
     "numpy",
     "pydantic",
-    "pydantic-settings",
     "python-dateutil",
     "requests",
 ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [
     "appdirs",
     "fire",
     "numpy",
-    "pydantic",
+    "pydantic>=2",
     "pydantic-settings",
     "python-dateutil",
     "python-dotenv",

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,10 @@ with open("xcc/_version.py") as f:
 
 requirements = [
     "appdirs",
+    "python-dotenv",
     "fire",
     "numpy",
-    "pydantic[dotenv]<2",
+    "pydantic",
     "python-dateutil",
     "requests",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,14 +19,14 @@ def connection() -> xcc.Connection:
 def settings(monkeypatch) -> Iterator[xcc.Settings]:
     """Returns a :class:`xcc.Settings` instance configured to use a mock .env file."""
     with NamedTemporaryFile("w") as env_file:
-        monkeypatch.setattr("xcc.Settings.Config.env_file", env_file.name)
+        monkeypatch.setitem(xcc.Settings.model_config, "env_file", env_file.name)
 
         settings_ = xcc.Settings(REFRESH_TOKEN="j.w.t", HOST="example.com", PORT=80, TLS=False)
         # Saving ensures that new Settings instances are loaded with the same values.
         settings_.save()
 
         # Environment variables take precedence over fields in the .env file.
-        for env_var in map(xcc.settings.get_name_of_env_var, settings_.dict()):
+        for env_var in map(xcc.settings.get_name_of_env_var, settings_.model_dump()):
             monkeypatch.delenv(env_var, raising=False)
 
         yield settings_

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -179,7 +179,10 @@ class TestSetSetting:
 
     def test_invalid_value(self):
         """Tests that a ValueError is raised when the value of a setting is invalid."""
-        match = r"Failed to update PORT setting: value is not a valid integer"
+        match = (
+            r"Failed to update PORT setting: "
+            r"Input should be a valid integer, unable to parse string as an integer"
+        )
         with pytest.raises(ValueError, match=match):
             xcc.commands.set_setting(name="PORT", value="string")
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,7 +15,7 @@ import xcc
 def env_file(monkeypatch):
     """Returns a mock .env file which :class:`xcc.Settings` is configured to use."""
     with NamedTemporaryFile("w") as env_file:
-        monkeypatch.setattr("xcc.settings.Settings.Config.env_file", env_file.name)
+        monkeypatch.setitem(xcc.Settings.model_config, "env_file", env_file.name)
         yield env_file
 
 
@@ -77,7 +77,7 @@ class TestSettings:
             settings.save()
 
         # Check that the .env file was not modified since there was a "\n" in the refresh token.
-        assert dotenv_values(xcc.Settings.Config.env_file) == {
+        assert dotenv_values(settings.model_config["env_file"]) == {
             "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t",
             "XANADU_CLOUD_HOST": "example.com",
             "XANADU_CLOUD_PORT": "80",
@@ -86,7 +86,7 @@ class TestSettings:
 
     def test_save_multiple_times(self, settings):
         """Tests that settings can be saved to a .env file multiple times."""
-        path_to_env_file = xcc.Settings.Config.env_file
+        path_to_env_file = settings.model_config["env_file"]
 
         settings.REFRESH_TOKEN = None
         settings.save()
@@ -108,7 +108,7 @@ class TestSettings:
         """Tests that settings can be saved to a .env file in a nonexistent directory."""
         with TemporaryDirectory() as env_dir:
             env_file = os.path.join(env_dir, "foo", "bar", ".env")
-            monkeypatch.setattr("xcc.settings.Settings.Config.env_file", env_file)
+            monkeypatch.setitem(xcc.Settings.model_config, "env_file", env_file)
 
             xcc.Settings().save()
             assert os.path.exists(env_file) is True

--- a/xcc/_version.py
+++ b/xcc/_version.py
@@ -3,4 +3,4 @@ This module specifies the XCC version number (<major>.<minor>.<patch>[-<pre-rele
 See https://semver.org/.
 """
 
-__version__ = "0.4.0-dev"
+__version__ = "0.3.2"

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -12,7 +12,7 @@ import fire
 import numpy as np
 from fire.core import FireError
 from fire.formatting import Error
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from ._version import __version__
 from .connection import Connection

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from appdirs import user_config_dir
 from dotenv import dotenv_values, set_key, unset_key
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Matches when string contains chars outside Base64URL set
 # https://base64.guru/standards/base64url
@@ -108,11 +108,7 @@ class Settings(BaseSettings):
 
     TLS: bool = True
     """Whether to use HTTPS for requests to the Xanadu Cloud."""
-
-    class Config:  # pylint: disable=missing-class-docstring
-        case_sensitive = True
-        env_file = get_path_to_env_file()
-        env_prefix = get_name_of_env_var()
+    model_config = SettingsConfigDict(case_sensitive=True, env_file=get_path_to_env_file(), env_prefix=get_name_of_env_var())
 
     def save(self) -> None:
         """Saves the current settings to the .env file."""

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from appdirs import user_config_dir
 from dotenv import dotenv_values, set_key, unset_key
-from pydantic.v1 import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Matches when string contains chars outside Base64URL set
 # https://base64.guru/standards/base64url
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
     >>> import xcc
     >>> settings = xcc.Settings()
     >>> settings
-    REFRESH_TOKEN=None ACCESS_TOKEN=None HOST='platform.xanadu.ai' PORT=443 TLS=True
+    Settings(REFRESH_TOKEN=None, ACCESS_TOKEN=None, HOST'platform.xanadu.ai', PORT=443, TLS=True)
 
     Now, individual options can be accessed or assigned through their
     corresponding attribute:
@@ -84,9 +84,9 @@ class Settings(BaseSettings):
 
         Several aggregate representations of options are also available, such as
 
-        >>> settings.dict()
+        >>> settings.model_dump()
         {'REFRESH_TOKEN': None, 'ACCESS_TOKEN': None, ..., 'TLS': True}
-        >>> settings.json()
+        >>> settings.model_dump_json()
         '{"REFRESH_TOKEN": null, "ACCESS_TOKEN": null, ..., "TLS": true}'
 
     Finally, saving a configuration can be done by invoking :meth:`Settings.save`:
@@ -109,25 +109,26 @@ class Settings(BaseSettings):
     TLS: bool = True
     """Whether to use HTTPS for requests to the Xanadu Cloud."""
 
-    class Config:  # pylint: disable=missing-class-docstring
-        case_sensitive = True
-        env_file = get_path_to_env_file()
-        env_prefix = get_name_of_env_var()
+    model_config = SettingsConfigDict(
+        case_sensitive=True,
+        env_file=get_path_to_env_file(),
+        env_prefix=get_name_of_env_var(),
+    )
 
     def save(self) -> None:
         """Saves the current settings to the .env file."""
 
-        env_file = Settings.Config.env_file
+        env_file = self.model_config["env_file"]
         env_dir = os.path.dirname(env_file)
         os.makedirs(env_dir, exist_ok=True)
 
         saved = dotenv_values(dotenv_path=env_file)
 
-        # must be done first as dict is not ordered
-        for key, val in self.dict().items():
+        # Must be done first as the dictionary is not ordered.
+        for key, val in self.model_dump().items():
             _check_for_invalid_values(key, val)
 
-        for key, val in self.dict().items():
+        for key, val in self.model_dump().items():
             field = get_name_of_env_var(key)
 
             # Remove keys that are assigned to None.

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -108,7 +108,9 @@ class Settings(BaseSettings):
 
     TLS: bool = True
     """Whether to use HTTPS for requests to the Xanadu Cloud."""
-    model_config = SettingsConfigDict(case_sensitive=True, env_file=get_path_to_env_file(), env_prefix=get_name_of_env_var())
+    model_config = SettingsConfigDict(
+        case_sensitive=True, env_file=get_path_to_env_file(), env_prefix=get_name_of_env_var()
+    )
 
     def save(self) -> None:
         """Saves the current settings to the .env file."""

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from appdirs import user_config_dir
 from dotenv import dotenv_values, set_key, unset_key
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic.v1 import BaseSettings
 
 # Matches when string contains chars outside Base64URL set
 # https://base64.guru/standards/base64url
@@ -108,9 +108,11 @@ class Settings(BaseSettings):
 
     TLS: bool = True
     """Whether to use HTTPS for requests to the Xanadu Cloud."""
-    model_config = SettingsConfigDict(
-        case_sensitive=True, env_file=get_path_to_env_file(), env_prefix=get_name_of_env_var()
-    )
+
+    class Config:  # pylint: disable=missing-class-docstring
+        case_sensitive = True
+        env_file = get_path_to_env_file()
+        env_prefix = get_name_of_env_var()
 
     def save(self) -> None:
         """Saves the current settings to the .env file."""


### PR DESCRIPTION
**Context:**
`pydantic` 2 comes with new features that one would like to take advantage of in various repos that import from `strtawberryfields` and the `xanadu-cloud-client` but is presently unable to due to `pydantic` being pinned to version `1.8.2` here.

**Description of the Change:**
Pins `pydantic` to version `2.4`.

**Benefits:**
Everyone can use the latest features of `pydantic`.

**Possible Drawbacks:**
Not likely to be many/any.

**Related GitHub Issues:**
N/A