### PR TITLE
Better Pydantic v2 support

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 appdirs==1.4.4
-python-dotenv==0.21.1
 fire==0.4.0
 numpy==1.21.3
 pydantic==2.4
+pydantic-settings==2.1.0
 python-dateutil==2.8.2
+python-dotenv==0.21.1
 requests==2.31.0

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,12 @@ with open("xcc/_version.py") as f:
 
 requirements = [
     "appdirs",
-    "python-dotenv",
     "fire",
     "numpy",
     "pydantic",
+    "pydantic-settings",
     "python-dateutil",
+    "python-dotenv",
     "requests",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,14 +19,14 @@ def connection() -> xcc.Connection:
 def settings(monkeypatch) -> Iterator[xcc.Settings]:
     """Returns a :class:`xcc.Settings` instance configured to use a mock .env file."""
     with NamedTemporaryFile("w") as env_file:
-        monkeypatch.setattr("xcc.Settings.Config.env_file", env_file.name)
+        monkeypatch.setitem(xcc.Settings.model_config, "env_file", env_file.name)
 
         settings_ = xcc.Settings(REFRESH_TOKEN="j.w.t", HOST="example.com", PORT=80, TLS=False)
         # Saving ensures that new Settings instances are loaded with the same values.
         settings_.save()
 
         # Environment variables take precedence over fields in the .env file.
-        for env_var in map(xcc.settings.get_name_of_env_var, settings_.dict()):
+        for env_var in map(xcc.settings.get_name_of_env_var, settings_.model_dump()):
             monkeypatch.delenv(env_var, raising=False)
 
         yield settings_

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -179,7 +179,10 @@ class TestSetSetting:
 
     def test_invalid_value(self):
         """Tests that a ValueError is raised when the value of a setting is invalid."""
-        match = r"Failed to update PORT setting: value is not a valid integer"
+        match = (
+            r"Failed to update PORT setting: "
+            r"Input should be a valid integer, unable to parse string as an integer"
+        )
         with pytest.raises(ValueError, match=match):
             xcc.commands.set_setting(name="PORT", value="string")
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,7 +15,7 @@ import xcc
 def env_file(monkeypatch):
     """Returns a mock .env file which :class:`xcc.Settings` is configured to use."""
     with NamedTemporaryFile("w") as env_file:
-        monkeypatch.setattr("xcc.settings.Settings.Config.env_file", env_file.name)
+        monkeypatch.setitem(xcc.Settings.model_config, "env_file", env_file.name)
         yield env_file
 
 
@@ -77,7 +77,7 @@ class TestSettings:
             settings.save()
 
         # Check that the .env file was not modified since there was a "\n" in the refresh token.
-        assert dotenv_values(xcc.Settings.Config.env_file) == {
+        assert dotenv_values(settings.model_config["env_file"]) == {
             "XANADU_CLOUD_REFRESH_TOKEN": "j.w.t",
             "XANADU_CLOUD_HOST": "example.com",
             "XANADU_CLOUD_PORT": "80",
@@ -86,7 +86,7 @@ class TestSettings:
 
     def test_save_multiple_times(self, settings):
         """Tests that settings can be saved to a .env file multiple times."""
-        path_to_env_file = xcc.Settings.Config.env_file
+        path_to_env_file = settings.model_config["env_file"]
 
         settings.REFRESH_TOKEN = None
         settings.save()
@@ -108,7 +108,7 @@ class TestSettings:
         """Tests that settings can be saved to a .env file in a nonexistent directory."""
         with TemporaryDirectory() as env_dir:
             env_file = os.path.join(env_dir, "foo", "bar", ".env")
-            monkeypatch.setattr("xcc.settings.Settings.Config.env_file", env_file)
+            monkeypatch.setitem(xcc.Settings.model_config, "env_file", env_file)
 
             xcc.Settings().save()
             assert os.path.exists(env_file) is True

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -12,7 +12,7 @@ import fire
 import numpy as np
 from fire.core import FireError
 from fire.formatting import Error
-from pydantic.v1 import ValidationError
+from pydantic import ValidationError
 
 from ._version import __version__
 from .connection import Connection

--- a/xcc/commands.py
+++ b/xcc/commands.py
@@ -87,7 +87,7 @@ def list_settings() -> Mapping[str, Any]:
     Returns:
         Mapping[str, Any]: Mapping from setting names to values.
     """
-    return Settings().dict()
+    return Settings().model_dump()
 
 
 @beautify
@@ -108,14 +108,14 @@ def set_setting(name: str, value: Union[str, int, bool]) -> str:
     key, _ = _resolve_setting(name)
 
     try:
-        settings = Settings(**{key: value})
+        settings = Settings.model_validate({key: value})
         settings.save()
     except ValidationError as exc:
         err = exc.errors()[0].get("msg", "invalid value")
         raise ValueError(f"Failed to update {key} setting: {err}") from exc
 
     # Using repr() ensures that strings are quoted.
-    val = repr(settings.dict()[key])
+    val = repr(settings.model_dump()[key])
     return f"Successfully updated {key} setting to {val}."
 
 
@@ -133,11 +133,11 @@ def _resolve_setting(name: str) -> Tuple[str, Any]:
     """
     key = name.upper()
 
-    settings = Settings()
-    if key not in settings.dict():
-        raise ValueError(f"The setting name '{name}' must be one of {list(settings.dict())}.")
+    settings_dict = Settings().model_dump()
+    if key not in settings_dict:
+        raise ValueError(f"The setting name '{name}' must be one of {list(settings_dict)}.")
 
-    return key, settings.dict()[key]
+    return key, settings_dict[key]
 
 
 # Device CLI

--- a/xcc/settings.py
+++ b/xcc/settings.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
     >>> import xcc
     >>> settings = xcc.Settings()
     >>> settings
-    REFRESH_TOKEN=None ACCESS_TOKEN=None HOST='platform.xanadu.ai' PORT=443 TLS=True
+    Settings(REFRESH_TOKEN=None, ACCESS_TOKEN=None, HOST'platform.xanadu.ai', PORT=443, TLS=True)
 
     Now, individual options can be accessed or assigned through their
     corresponding attribute:
@@ -84,9 +84,9 @@ class Settings(BaseSettings):
 
         Several aggregate representations of options are also available, such as
 
-        >>> settings.dict()
+        >>> settings.model_dump()
         {'REFRESH_TOKEN': None, 'ACCESS_TOKEN': None, ..., 'TLS': True}
-        >>> settings.json()
+        >>> settings.model_dump_json()
         '{"REFRESH_TOKEN": null, "ACCESS_TOKEN": null, ..., "TLS": true}'
 
     Finally, saving a configuration can be done by invoking :meth:`Settings.save`:


### PR DESCRIPTION
**Context:**

PR #46 upgrades Pydantic from v1 to v2 but does not actually replace the v1 features with their v2 counterparts.

**Description of the Change:**

* Added `pydantic-settings` as a new dependency.
* Replaced the nested `xcc.Settings.Config` class with a `SettingsConfigDict` field.
* Fixed a number of warnings by replacing `xcc.Settings.dict()` with `xcc.Settings.model_dump()`.
* Dropped support for EOL Python 3.7.

**Benefits:**

* Running tests no longer yields any warnings.
* Simpler future upgrade path to Pydantic v3.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.