### PR TITLE
Fix Read the Docs configuration

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## Release 0.4.0 (development release)
 
+### Bug fixes
+
+* Fixed an issue with the Read the Docs configuration. [(#49)](https://github.com/XanaduAI/xanadu-cloud-client/pull/49)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
 
 ## Release 0.3.2 (current release)
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,11 +4,14 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-    version: 3.7
-    install:
-        - requirements: docs/requirements.txt
-        - method: pip
-          path: .
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
 
 build:
-    image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+  apt_packages:
+    - graphviz


### PR DESCRIPTION
**Context:**

Currently, the Read the Docs builds are failing due to the following error:
> Error
> Problem in your project's configuration. Invalid configuration option "build.os": os not found

**Description of the Change:**

* Fixed the Read the Docs configuration file based on the [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme/blob/master/.readthedocs.yml).

**Benefits:**

* The Read the Docs builds are passing.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.